### PR TITLE
Include <stdlib.h> for malloc and free.

### DIFF
--- a/src/nfd_gtk.cpp
+++ b/src/nfd_gtk.cpp
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <string.h>
 #include <gtk/gtk.h>
+#include <stdlib.h>
 #include "nfd.h"
 
 


### PR DESCRIPTION
Didn't compile on Ubuntu 16.04 due to missing include for <stdlib.h>, resulting in error messages that malloc and free are not defined.

I'm unsure why this isn't a problem on Ubuntu 18.04.