### PR TITLE
Fix Linux GCC warnings

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,4 +1,4 @@
-name: C/C++ CI
+name: build
 
 on:
   push:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Installing Dependencies
       run: sudo apt-get update && sudo apt-get install libgtk-3-dev
     - name: Configure
-      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic" ..
+      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" ..
     - name: Build
       run: cmake --build build
   
@@ -29,7 +29,7 @@ jobs:
     - name: Installing Dependencies
       run: sudo apt-get update && sudo apt-get install libgtk-3-dev
     - name: Configure
-      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic" ..
+      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" ..
     - name: Build
       run: cmake --build build
   
@@ -42,7 +42,7 @@ jobs:
     - name: Installing Dependencies
       run: sudo apt-get update && sudo apt-get install libgtk-3-dev
     - name: Configure
-      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic" ..
+      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" ..
     - name: Build
       run: cmake --build build
   
@@ -53,7 +53,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Configure
-      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic" ..
+      run: mkdir build && cd build && cmake -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" ..
     - name: Build
       run: cmake --build build
   

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 # Native File Dialog Extended
 
+![GitHub Actions](https://github.com/btzy/nativefiledialog-extended/workflows/build/badge.svg)
+
 A small C library with that portably invokes native file open, folder select and save dialogs.  Write dialog code once and have it pop up native dialogs on all supported platforms.  Avoid linking large dependencies like wxWidgets and Qt.
 
 This library is based on Michael Labbe's Native File Dialog ([mlabbe/nativefiledialog](https://github.com/mlabbe/nativefiledialog)).

--- a/src/nfd_gtk.cpp
+++ b/src/nfd_gtk.cpp
@@ -129,7 +129,7 @@ namespace {
                         *p_extnBufEnd++ = '.';
                         p_extnBufEnd = copy(p_extensionStart, p_spec, p_extnBufEnd);
                         *p_extnBufEnd++ = '\0';
-                        assert(p_extnBufEnd - extnBuf == sizeof(nfdnchar_t) * (p_spec - p_extensionStart + 3));
+                        assert((size_t)(p_extnBufEnd - extnBuf) == sizeof(nfdnchar_t) * (p_spec - p_extensionStart + 3));
                         gtk_file_filter_add_pattern(filter, extnBuf);
                         NFDi_Free(extnBuf);
 
@@ -148,7 +148,7 @@ namespace {
                 }
                 *p_nameBuf++ = ')';
                 *p_nameBuf++ = '\0';
-                assert(p_nameBuf - nameBuf == sizeof(nfdnchar_t) * nameSize);
+                assert((size_t)(p_nameBuf - nameBuf) == sizeof(nfdnchar_t) * nameSize);
 
                 // add to the filter
                 gtk_file_filter_set_name(filter, nameBuf);
@@ -225,7 +225,7 @@ namespace {
                         *p_extnBufEnd++ = '.';
                         p_extnBufEnd = copy(p_extensionStart, p_spec, p_extnBufEnd);
                         *p_extnBufEnd++ = '\0';
-                        assert(p_extnBufEnd - extnBuf == sizeof(nfdnchar_t) * (p_spec - p_extensionStart + 3));
+                        assert((size_t)(p_extnBufEnd - extnBuf) == sizeof(nfdnchar_t) * (p_spec - p_extensionStart + 3));
                         gtk_file_filter_add_pattern(filter, extnBuf);
                         NFDi_Free(extnBuf);
                         
@@ -249,7 +249,7 @@ namespace {
                 }
                 *p_nameBuf++ = ')';
                 *p_nameBuf++ = '\0';
-                assert(p_nameBuf - nameBuf == sizeof(nfdnchar_t) * nameSize);
+                assert((size_t)(p_nameBuf - nameBuf) == sizeof(nfdnchar_t) * nameSize);
                 
                 // add to the filter
                 gtk_file_filter_set_name(filter, nameBuf);
@@ -311,7 +311,9 @@ namespace {
     
     static void FileActivatedSignalHandler(GtkButton* saveButton, void* userdata)
     {
-		ButtonClickedArgs* args = static_cast<ButtonClickedArgs*>(userdata);
+        (void)saveButton; // silence the unused arg warning
+
+        ButtonClickedArgs* args = static_cast<ButtonClickedArgs*>(userdata);
 		GtkFileChooser* chooser = args->chooser;
 		char* currentFileName = gtk_file_chooser_get_current_name(chooser);
 		if (*currentFileName) { // string is not empty

--- a/src/nfd_gtk.cpp
+++ b/src/nfd_gtk.cpp
@@ -70,17 +70,17 @@ namespace {
     
     // Does not own the filter and extension.
     struct Pair_GtkFileFilter_FileExtension {
-		GtkFileFilter* filter;
-		const nfdnchar_t* extensionBegin;
-		const nfdnchar_t* extensionEnd;
-	};
-	
-	struct ButtonClickedArgs {
-		Pair_GtkFileFilter_FileExtension* map;
-		GtkFileChooser* chooser;
-	};
-	
-	
+        GtkFileFilter* filter;
+        const nfdnchar_t* extensionBegin;
+        const nfdnchar_t* extensionEnd;
+    };
+    
+    struct ButtonClickedArgs {
+        Pair_GtkFileFilter_FileExtension* map;
+        GtkFileChooser* chooser;
+    };
+    
+    
     void AddFiltersToDialog(GtkFileChooser* chooser, const nfdnfilteritem_t* filterList, nfdfiltersize_t filterCount) {
         
         if (filterCount) {
@@ -231,8 +231,8 @@ namespace {
                         
                         // store current pointer in map (if it's the first one)
                         if (map[index].extensionEnd == nullptr) {
-							map[index].extensionEnd = p_spec;
-						}
+                            map[index].extensionEnd = p_spec;
+                        }
 
                         if (*p_spec) {
                             // update the extension start point
@@ -314,47 +314,47 @@ namespace {
         (void)saveButton; // silence the unused arg warning
 
         ButtonClickedArgs* args = static_cast<ButtonClickedArgs*>(userdata);
-		GtkFileChooser* chooser = args->chooser;
-		char* currentFileName = gtk_file_chooser_get_current_name(chooser);
-		if (*currentFileName) { // string is not empty
-			
-			// find a '.' in the file name
-			const char* p_period = currentFileName;
-			for (;*p_period; ++p_period) {
-				if (*p_period == '.') {
-					break;
-				}
-			}
-			
-			if (!*p_period) { // there is no '.', so append the default extension
-				Pair_GtkFileFilter_FileExtension* filterMap = static_cast<Pair_GtkFileFilter_FileExtension*>(args->map);
-				GtkFileFilter* currentFilter = gtk_file_chooser_get_filter(chooser);
-				if (currentFilter) {
-					for (;filterMap->filter; ++filterMap) {
-						if (filterMap->filter == currentFilter) break;
-					}
-				}
-				if (filterMap->filter) {
-					// memory for appended string (including '.' and trailing '\0')
-					char* appendedFileName = NFDi_Malloc<char>(sizeof(char) * ((p_period - currentFileName) + (filterMap->extensionEnd - filterMap->extensionBegin) + 2));
-					char* p_fileName = copy(currentFileName, p_period, appendedFileName);
-					*p_fileName++ = '.';
-					p_fileName = copy(filterMap->extensionBegin, filterMap->extensionEnd, p_fileName);
-					*p_fileName++ = '\0';
-					
-					assert(p_fileName - appendedFileName == (p_period - currentFileName) + (filterMap->extensionEnd - filterMap->extensionBegin) + 2);
-					
-					// set the appended file name
-					gtk_file_chooser_set_current_name(chooser, appendedFileName);
-					
-					// free the memory
-					NFDi_Free(appendedFileName);
-				}
-			}
-		}
-		
-		// free the memory
-		g_free(currentFileName);
+        GtkFileChooser* chooser = args->chooser;
+        char* currentFileName = gtk_file_chooser_get_current_name(chooser);
+        if (*currentFileName) { // string is not empty
+            
+            // find a '.' in the file name
+            const char* p_period = currentFileName;
+            for (;*p_period; ++p_period) {
+                if (*p_period == '.') {
+                    break;
+                }
+            }
+            
+            if (!*p_period) { // there is no '.', so append the default extension
+                Pair_GtkFileFilter_FileExtension* filterMap = static_cast<Pair_GtkFileFilter_FileExtension*>(args->map);
+                GtkFileFilter* currentFilter = gtk_file_chooser_get_filter(chooser);
+                if (currentFilter) {
+                    for (;filterMap->filter; ++filterMap) {
+                        if (filterMap->filter == currentFilter) break;
+                    }
+                }
+                if (filterMap->filter) {
+                    // memory for appended string (including '.' and trailing '\0')
+                    char* appendedFileName = NFDi_Malloc<char>(sizeof(char) * ((p_period - currentFileName) + (filterMap->extensionEnd - filterMap->extensionBegin) + 2));
+                    char* p_fileName = copy(currentFileName, p_period, appendedFileName);
+                    *p_fileName++ = '.';
+                    p_fileName = copy(filterMap->extensionBegin, filterMap->extensionEnd, p_fileName);
+                    *p_fileName++ = '\0';
+                    
+                    assert(p_fileName - appendedFileName == (p_period - currentFileName) + (filterMap->extensionEnd - filterMap->extensionBegin) + 2);
+                    
+                    // set the appended file name
+                    gtk_file_chooser_set_current_name(chooser, appendedFileName);
+                    
+                    // free the memory
+                    NFDi_Free(appendedFileName);
+                }
+            }
+        }
+        
+        // free the memory
+        g_free(currentFileName);
     }
 }
 
@@ -497,15 +497,15 @@ nfdresult_t NFD_SaveDialogN( nfdnchar_t **outPath,
     
     /* set the handler to add file extension */
     gulong handlerID = g_signal_connect(G_OBJECT(saveButton), "pressed", G_CALLBACK(FileActivatedSignalHandler), static_cast<void*>(&buttonClickedArgs));
-	
-	/* invoke the dialog (blocks until dialog is closed) */
-	gint result = gtk_dialog_run(GTK_DIALOG(widget));
-	
-	/* unset the handler */
-	g_signal_handler_disconnect(G_OBJECT(saveButton), handlerID);
-	
-	/* free the filter map */
-	NFDi_Free(buttonClickedArgs.map);
+    
+    /* invoke the dialog (blocks until dialog is closed) */
+    gint result = gtk_dialog_run(GTK_DIALOG(widget));
+    
+    /* unset the handler */
+    g_signal_handler_disconnect(G_OBJECT(saveButton), handlerID);
+    
+    /* free the filter map */
+    NFDi_Free(buttonClickedArgs.map);
     
     if (result == GTK_RESPONSE_ACCEPT) {
         // write out the file name


### PR DESCRIPTION
Fix Linux GCC warnings, and compile for GCC and Clang with `-Werror`.  Resolves #5.