### PR TITLE
Add flag for building tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,8 @@ message("nfd Compiler: ${nfd_COMPILER}")
 set (CMAKE_CXX_STANDARD 17)
 
 add_subdirectory(src)
-add_subdirectory(test)
+
+option(NFD_BUILD_TESTS "Build tests for nfd" OFF)
+if(${NFD_BUILD_TESTS})
+    add_subdirectory(test)
+endif()


### PR DESCRIPTION
Currently, the test targets are always built. This change adds a flag for that, so they aren't built when used from another cmake project by default.