### PR TITLE
Clarify build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,6 @@ and it probably works on Visual Studio 2017 too.
 ### Linux
 `apt-get libgtk-3-dev` installs the GTK+3 dependency on debian based systems.
 
-You have the option of compiling and linking against GTK+.
-If you use it, the recommended way to compile is to include the arguments of `pkg-config --cflags --libs gtk+-3.0`.
-
 ### MacOS
 On Mac OS, add `AppKit` to the list of frameworks.
 

--- a/README.md
+++ b/README.md
@@ -136,8 +136,6 @@ and it probably works on Visual Studio 2017 too.
 You have the option of compiling and linking against GTK+.
 If you use it, the recommended way to compile is to include the arguments of `pkg-config --cflags --libs gtk+-3.0`.
 
-~~Alternatively, you can use the Zenity backend by running the Makefile in `build/gmake_linux_zenity`.  Zenity runs the dialog in its own address space, but requires the user to have Zenity correctly installed and configured on their system.~~  Zenity has not been ported to Native File Dialog Extended yet.
-
 ### MacOS
 On Mac OS, add `AppKit` to the list of frameworks.
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,17 @@ See [NFD.h](src/include/nfd.h) for more options.
 
 # Building ##
 
-## Building the Library
+## CMake Projects
+If your project uses CMake,
+simply add the following lines to your CMakeLists.txt:
+```
+add_subdirectory(path/to/nativefiledialog-extended)
+target_link_libraries(MyProgram PRIVATE nfd)
+```
 
-Native File Dialog Extended uses [CMake]([https://cmake.org/](https://cmake.org/)).  Before compiling your programs, you need to build the static library.
-
-To build the static library, execute the following commands in a terminal (starting from the project root directory):
+## Standalone Library
+To build the static library, execute the following commands in a terminal
+(starting from the project root directory):
 ```
 mkdir build
 cd build
@@ -97,13 +103,21 @@ cmake -DCMAKE_BUILD_TYPE=Release ..
 cmake --build .
 ```
 
-The above commands will make a `build` directory, and build the project (in release mode) there.  If you are developing NFD, you may want to do `-DCMAKE_BUILD_TYPE=Debug` to build a debug version of the library instead.
+The above commands will make a `build` directory,
+and build the project (in release mode) there.
+If you are developing NFD, you may want to do `-DCMAKE_BUILD_TYPE=Debug`
+to build a debug version of the library instead.
 
-If you want to build the sample programs, add `-DNFD_BUILD_TESTS=ON` (samples programs are not built by default).
+If you want to build the sample programs,
+add `-DNFD_BUILD_TESTS=ON` (samples programs are not built by default).
 
 ### Visual Studio on Windows
-
-Recent versions of Visual Studio have CMake support built into the IDE.  You should be able to "Open Folder" in the project root directory, and Visual Studio will recognize and configure the project appropriately.  From there, you will be able to set configurations for Debug vs Release, and for x86 vs x64.  For more information, see [the Microsoft Docs page]([https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019)).
+Recent versions of Visual Studio have CMake support built into the IDE. 
+You should be able to "Open Folder" in the project root directory,
+and Visual Studio will recognize and configure the project appropriately.
+From there, you will be able to set configurations for Debug vs Release,
+and for x86 vs x64. 
+For more information, see [the Microsoft Docs page]([https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019)).
 
 This has been tested to work on Visual Studio 2019, and it probably works on Visual Studio 2017 too.
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ target_link_libraries(MyProgram PRIVATE nfd)
 Make sure that you also have the needed [dependencies](#dependencies).
 
 ## Standalone Library
-To build the static library, execute the following commands
-(starting from the project root directory):
+If you want to build the standalone static library,
+execute the following commands (starting from the project root directory):
 ```
 mkdir build
 cd build

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [NFD.h](src/include/nfd.h) for more options.
 
 (TODO)
 
-# Building ##
+# Building
 
 ## CMake Projects
 If your project uses CMake,
@@ -119,17 +119,18 @@ and Visual Studio will recognize and configure the project appropriately.
 From there, you will be able to set configurations for Debug vs Release,
 and for x86 vs x64. 
 For more information, see [the Microsoft Docs page]([https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019)).
-This has been tested to work on Visual Studio 2019, and it probably works on Visual Studio 2017 too.
+This has been tested to work on Visual Studio 2019,
+and it probably works on Visual Studio 2017 too.
 
-### Compiling Your Programs ###
+### Compiling Your Programs
 
  1. Add `src/include` to your include search path.
  2. Add `nfd.lib` or `nfd_d.lib` to the list of static libraries to link against (for release or debug, respectively).
  3. Add `build/<debug|release>/<arch>` to the library search path.
 
-# Dependencies
+## Dependencies
 
-## Linux
+### Linux
 `apt-get libgtk-3-dev` installs the GTK+3 dependency on debian based systems.
 
 You have the option of compiling and linking against GTK+.
@@ -137,10 +138,10 @@ If you use it, the recommended way to compile is to include the arguments of `pk
 
 ~~Alternatively, you can use the Zenity backend by running the Makefile in `build/gmake_linux_zenity`.  Zenity runs the dialog in its own address space, but requires the user to have Zenity correctly installed and configured on their system.~~  Zenity has not been ported to Native File Dialog Extended yet.
 
-## MacOS
+### MacOS
 On Mac OS, add `AppKit` to the list of frameworks.
 
-## Windows
+### Windows
 On Windows, ensure you are building against `comctl32.lib` and `uuid.lib`.
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ simply add the following lines to your CMakeLists.txt:
 add_subdirectory(path/to/nativefiledialog-extended)
 target_link_libraries(MyProgram PRIVATE nfd)
 ```
+Make sure that you also have the needed [dependencies](#dependencies).
 
 ## Standalone Library
-To build the static library, execute the following commands in a terminal
+To build the static library, execute the following commands
 (starting from the project root directory):
 ```
 mkdir build
@@ -118,24 +119,28 @@ and Visual Studio will recognize and configure the project appropriately.
 From there, you will be able to set configurations for Debug vs Release,
 and for x86 vs x64. 
 For more information, see [the Microsoft Docs page]([https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019](https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=vs-2019)).
-
 This has been tested to work on Visual Studio 2019, and it probably works on Visual Studio 2017 too.
 
-## Compiling Your Programs ###
+### Compiling Your Programs ###
 
  1. Add `src/include` to your include search path.
  2. Add `nfd.lib` or `nfd_d.lib` to the list of static libraries to link against (for release or debug, respectively).
  3. Add `build/<debug|release>/<arch>` to the library search path.
 
-### Linux ####
-On Linux, you have the option of compiling and linking against GTK+.  If you use it, the recommended way to compile is to include the arguments of `pkg-config --cflags --libs gtk+-3.0`.
+# Dependencies
+
+## Linux
+`apt-get libgtk-3-dev` installs the GTK+3 dependency on debian based systems.
+
+You have the option of compiling and linking against GTK+.
+If you use it, the recommended way to compile is to include the arguments of `pkg-config --cflags --libs gtk+-3.0`.
 
 ~~Alternatively, you can use the Zenity backend by running the Makefile in `build/gmake_linux_zenity`.  Zenity runs the dialog in its own address space, but requires the user to have Zenity correctly installed and configured on their system.~~  Zenity has not been ported to Native File Dialog Extended yet.
 
-### MacOS ####
+## MacOS
 On Mac OS, add `AppKit` to the list of frameworks.
 
-### Windows ####
+## Windows
 On Windows, ensure you are building against `comctl32.lib` and `uuid.lib`.
 
 # Usage


### PR DESCRIPTION
This addresses #19.
I took the liberty of breaking off some lines before the 80 column mark, makes it easier to read the source.
Also removed the comment about Zenity, as I didn't think it fit there and was mostly distracting.

I left the instruction on how to build it separately, as I don't know if nfde aims to support non-cmake projects.
If it doesn't, it should be possible to make the instructions even more straightforward.

Also, is the pkg-config comment under Linux still relevant?
Don't know what that part does but wouldn't surprise me if it was make specific.