### PR TITLE
Implement enumerator (aka iterator) for PathSet

### DIFF
--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -27,6 +27,9 @@ typedef char nfdnchar_t;
 
 /* opaque data structure -- see NFD_PathSet_* */
 typedef void nfdpathset_t;
+typedef struct {
+    void* ptr;
+} nfdpathsetenum_t;
 
 typedef unsigned int nfdfiltersize_t;
 
@@ -109,11 +112,11 @@ typedef unsigned long nfdpathsetsize_t;
 typedef unsigned int nfdpathsetsize_t;
 #endif  // _WIN32, __APPLE__
 
-/* get the number of entries stored in pathSet */
+/* Gets the number of entries stored in pathSet */
 /* note that some paths might be invalid (NFD_ERROR will be returned by NFD_PathSet_GetPath), so we
  * might not actually have this number of usable paths */
 nfdresult_t NFD_PathSet_GetCount(const nfdpathset_t* pathSet, nfdpathsetsize_t* count);
-/* Get the UTF-8 path at offset index */
+/* Gets the UTF-8 path at offset index */
 /* It is the caller's responsibility to free `outPath` via NFD_PathSet_FreePathN() if this function
  * returns NFD_OKAY */
 nfdresult_t NFD_PathSet_GetPathN(const nfdpathset_t* pathSet,
@@ -127,6 +130,19 @@ nfdresult_t NFD_PathSet_GetPathN(const nfdpathset_t* pathSet,
 #else
 void NFD_PathSet_FreePathN(const nfdnchar_t* filePath);
 #endif  // _WIN32, __APPLE__
+
+/* Gets an enumerator of the path set. */
+/* It is the caller's responsibility to free `enumerator` via NFD_PathSet_FreeEnum() if this
+ * function returns NFD_OKAY, and it should be freed before freeing the pathset. */
+nfdresult_t NFD_PathSet_GetEnum(const nfdpathset_t* pathSet, nfdpathsetenum_t* outEnumerator);
+/* Frees an enumerator of the path set. */
+void NFD_PathSet_FreeEnum(nfdpathsetenum_t* enumerator);
+/* Gets the next item from the path set enumerator.
+ * If there are no more items, then *outPaths will be set to NULL. */
+/* It is the caller's responsibility to free `*outPath` via NFD_PathSet_FreePath() if this
+ * function returns NFD_OKAY and `*outPath` is not null */
+nfdresult_t NFD_PathSet_EnumNextN(nfdpathsetenum_t* enumerator, nfdnchar_t** outPath);
+
 /* Free the pathSet */
 void NFD_PathSet_Free(const nfdpathset_t* pathSet);
 
@@ -184,6 +200,12 @@ nfdresult_t NFD_PathSet_GetPathU8(const nfdpathset_t* pathSet,
                                   nfdpathsetsize_t index,
                                   nfdu8char_t** outPath);
 
+/* Gets the next item from the path set enumerator.
+ * If there are no more items, then *outPaths will be set to NULL. */
+/* It is the caller's responsibility to free `*outPath` via NFD_PathSet_FreePathU8() if this
+ * function returns NFD_OKAY and `*outPath` is not null */
+nfdresult_t NFD_PathSet_EnumNextU8(nfdpathsetenum_t* enumerator, nfdu8char_t** outPath);
+
 #define NFD_PathSet_FreePathU8 NFD_FreePathU8
 
 #ifdef NFD_NATIVE
@@ -196,6 +218,7 @@ typedef nfdnfilteritem_t nfdfilteritem_t;
 #define NFD_PickFolder NFD_PickFolderN
 #define NFD_PathSet_GetPath NFD_PathSet_GetPathN
 #define NFD_PathSet_FreePath NFD_PathSet_FreePathN
+#define NFD_PathSet_EnumNext NFD_PathSet_EnumNextN
 #else
 typedef nfdu8char_t nfdchar_t;
 typedef nfdu8filteritem_t nfdfilteritem_t;
@@ -206,6 +229,7 @@ typedef nfdu8filteritem_t nfdfilteritem_t;
 #define NFD_PickFolder NFD_PickFolderU8
 #define NFD_PathSet_GetPath NFD_PathSet_GetPathU8
 #define NFD_PathSet_FreePath NFD_PathSet_FreePathU8
+#define NFD_PathSet_EnumNext NFD_PathSet_EnumNextU8
 #endif  // NFD_NATIVE
 
 #else  // _WIN32
@@ -220,6 +244,7 @@ typedef nfdnfilteritem_t nfdfilteritem_t;
 #define NFD_PickFolder NFD_PickFolderN
 #define NFD_PathSet_GetPath NFD_PathSet_GetPathN
 #define NFD_PathSet_FreePath NFD_PathSet_FreePathN
+#define NFD_PathSet_EnumNext NFD_PathSet_EnumNextN
 typedef nfdnchar_t nfdu8char_t;
 typedef nfdnfilteritem_t nfdu8filteritem_t;
 #define NFD_FreePathU8 NFD_FreePathN
@@ -229,6 +254,7 @@ typedef nfdnfilteritem_t nfdu8filteritem_t;
 #define NFD_PickFolderU8 NFD_PickFolderN
 #define NFD_PathSet_GetPathU8 NFD_PathSet_GetPathN
 #define NFD_PathSet_FreePathU8 NFD_PathSet_FreePathN
+#define NFD_PathSet_EnumNextU8 NFD_PathSet_EnumNextN
 
 #endif  // _WIN32
 

--- a/src/nfd_gtk.cpp
+++ b/src/nfd_gtk.cpp
@@ -581,3 +581,27 @@ void NFD_PathSet_Free(const nfdpathset_t* pathSet) {
     // free the path set memory
     g_slist_free(fileList);
 }
+
+nfdresult_t NFD_PathSet_GetEnum(const nfdpathset_t* pathSet, nfdpathsetenum_t* outEnumerator) {
+    // The pathset (GSList) is already a linked list, so the enumeration is itself
+    outEnumerator->ptr = const_cast<void*>(pathSet);
+
+    return NFD_OKAY;
+}
+
+void NFD_PathSet_FreeEnum(nfdpathsetenum_t*) {
+    // Do nothing, because the enumeration is the pathset itself
+}
+
+nfdresult_t NFD_PathSet_EnumNextN(nfdpathsetenum_t* enumerator, nfdnchar_t** outPath) {
+    const GSList* fileList = static_cast<const GSList*>(enumerator->ptr);
+
+    if (fileList) {
+        *outPath = static_cast<nfdnchar_t*>(fileList->data);
+        enumerator->ptr = static_cast<void*>(fileList->next);
+    } else {
+        *outPath = nullptr;
+    }
+
+    return NFD_OKAY;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TEST_LIST
   test_opendialog_cpp.cpp
   test_opendialogmultiple.c
   test_opendialogmultiple_cpp.cpp
+  test_opendialogmultiple_enum.c
   test_pickfolder.c
   test_pickfolder_cpp.cpp
   test_savedialog.c)

--- a/test/test_opendialogmultiple_enum.c
+++ b/test/test_opendialogmultiple_enum.c
@@ -1,0 +1,53 @@
+#include <nfd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* this test should compile on all supported platforms */
+
+int main(void) {
+    // initialize NFD
+    // either call NFD_Init at the start of your program and NFD_Quit at the end of your program,
+    // or before/after every time you want to show a file dialog.
+    NFD_Init();
+
+    const nfdpathset_t* outPaths;
+
+    // prepare filters for the dialog
+    nfdfilteritem_t filterItem[2] = {{"Source code", "c,cpp,cc"}, {"Headers", "h,hpp"}};
+
+    // show the dialog
+    nfdresult_t result = NFD_OpenDialogMultiple(&outPaths, filterItem, 2, NULL);
+
+    if (result == NFD_OKAY) {
+        puts("Success!");
+
+        // declare enumerator (not a pointer)
+        nfdpathsetenum_t enumerator;
+
+        NFD_PathSet_GetEnum(outPaths, &enumerator);
+        nfdchar_t* path;
+        unsigned i = 0;
+        while (NFD_PathSet_EnumNext(&enumerator, &path) && path) {
+            printf("Path %u: %s\n", i++, path);
+
+            // remember to free the pathset path with NFD_PathSet_FreePath (not NFD_FreePath!)
+            NFD_PathSet_FreePath(path);
+        }
+
+        // remember to free the pathset enumerator memory (before freeing the pathset)
+        NFD_PathSet_FreeEnum(&enumerator);
+
+        // remember to free the pathset memory (since NFD_OKAY is returned)
+        NFD_PathSet_Free(outPaths);
+    } else if (result == NFD_CANCEL) {
+        puts("User pressed cancel.");
+    } else {
+        printf("Error: %s\n", NFD_GetError());
+    }
+
+    // Quit NFD
+    NFD_Quit();
+
+    return 0;
+}


### PR DESCRIPTION
Benefits:
- Nicer API for use with C++ and Rust iterators
- O(N) instead of O(N^2) retrieval of paths