### PR TITLE
MacOS: Use allowedContentTypes on >=12.0 instead of allowedFileTypes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2.1
+
+jobs:
+  build:
+    macos:
+      xcode: 13.3
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            brew install cmake
+      - run: 
+          name: Configure
+          command: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_BUILD_TESTS=ON ..
+      - run:
+          name: Build
+          command: cmake --build build --target install
+
+workflows:
+  main: 
+    jobs:
+      - build:
+          name: MacOS 12 - Clang

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Installing Dependencies
       run: sudo apt-get update && sudo apt-get install ${{ matrix.portal.dep }}
     - name: Configure
-      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.compiler.c }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }} -DCMAKE_CXX_STANDARD=${{ matrix.cppstd }} -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_PORTAL=${{ matrix.portal.flag }} -DNFD_BUILD_TESTS=ON ..
+      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.compiler.c }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }} -DCMAKE_CXX_STANDARD=${{ matrix.cppstd }} -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_PORTAL=${{ matrix.portal.flag }} -DNFD_BUILD_TESTS=ON ..
     - name: Build
       run: cmake --build build --target install
     - name: Upload test binaries
@@ -58,7 +58,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Configure
-      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_BUILD_TESTS=ON ..
+      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_BUILD_TESTS=ON ..
     - name: Build
       run: cmake --build build --target install
     - name: Upload test binaries
@@ -130,7 +130,7 @@ jobs:
           mingw-w64-x86_64-gcc
           mingw-w64-x86_64-cmake
     - name: Configure
-      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -G 'MSYS Makefiles' -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_BUILD_TESTS=ON ..
+      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DCMAKE_CXX_COMPILER=x86_64-w64-mingw32-g++ -G 'MSYS Makefiles' -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_BUILD_TESTS=ON ..
     - name: Build
       run: cmake --build build --target install
     - name: Upload test binaries

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Make sure `libgtk-3-dev` is installed on your system.
 Make sure `libdbus-1-dev` is installed on your system.
 
 ### MacOS
-On MacOS, add `AppKit` to the list of frameworks.
+On MacOS, add `AppKit` and `UniformTypeIdentifiers` to the list of frameworks.
 
 ### Windows
 On Windows (both MSVC and MinGW), ensure you are building against `ole32.lib` and `uuid.lib`.
@@ -255,6 +255,12 @@ To use the portal implementation, add `-DNFD_PORTAL=ON` to the build command.
 Unlike Windows and MacOS, Linux does not have a file chooser baked into the operating system.  Linux applications that want a file chooser usually link with a library that provides one (such as GTK, as in the Linux screenshot above).  This is a mostly acceptable solution that many applications use, but may make the file chooser look foreign on non-GTK distros.
 
 Flatpak was introduced in 2015, and with it came a standardized interface to open a file chooser.  Applications using this interface did not need to come with a file chooser, and could use the one provided by Flatpak.  This interface became known as the desktop portal, and its use expanded to non-Flatpak applications.  Now, most major desktop Linux distros come with the desktop portal installed, with file choosers that fit the theme of the distro.  Users can also install a different portal backend if desired.  There are currently two known backends: GTK and KDE.  (XFCE does not currently seem to have a portal backend.)
+
+## Platform-specific Quirks
+
+### MacOS
+
+- On MacOS ≥ 12.0, if you are filtering by a file extension specific to your application, you will need to define the data type in your `Info.plist` file as per the [Apple documentation](https://developer.apple.com/documentation/uniformtypeidentifiers/defining_file_and_data_types_for_your_app).
 
 # Known Limitations #
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ endif()
 
 if(nfd_PLATFORM STREQUAL PLATFORM_MACOS)
   find_library(APPKIT_LIBRARY AppKit)
+  find_library(UNIFORMTYPEIDENTIFIERS_LIBRARY UniformTypeIdentifiers)
   list(APPEND SOURCE_FILES nfd_cocoa.m)
 endif()
 
@@ -55,8 +56,13 @@ if(nfd_PLATFORM STREQUAL PLATFORM_LINUX)
 endif()
 
 if(nfd_PLATFORM STREQUAL PLATFORM_MACOS)
-  target_link_libraries(${TARGET_NAME}
-    PRIVATE ${APPKIT_LIBRARY})
+    if(UNIFORMTYPEIDENTIFIERS_LIBRARY)
+      target_link_libraries(${TARGET_NAME}
+        PRIVATE ${APPKIT_LIBRARY} ${UNIFORMTYPEIDENTIFIERS_LIBRARY})
+    else()
+      target_link_libraries(${TARGET_NAME}
+        PRIVATE ${APPKIT_LIBRARY})
+    endif()
 endif()
 
 if(nfd_COMPILER STREQUAL COMPILER_MSVC)


### PR DESCRIPTION
The `allowedFileTypes` property is deprecated on MacOS >= 12.0, and will probably be removed in the future.  This PR makes NFD use the `allowedContentTypes` property on MacOS >= 12.0 (using a runtime check if necessary, because old versions of MacOS may not have the UniformTypeIdentifiers library needed for `allowedContentTypes` to work).

This may be a breaking change on MacOS >= 12.0 for projects that use custom file extensions. If that is the case, an `Info.plist` file needs to be added to the app to define the custom file extension, as per [the Apple documentation](https://developer.apple.com/documentation/uniformtypeidentifiers/defining_file_and_data_types_for_your_app?language=objc). Going forward, the `allowedFileTypes` property will probably be removed, so this will eventually be the only way to make custom file extensions work on MacOS.