### PR TITLE
Portal: Don't automatically append file extension in SaveDialog()

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,15 +22,27 @@ jobs:
 
   build-ubuntu:
     
-    name: Ubuntu ${{ matrix.os.name }} - ${{ matrix.compiler.name }}, ${{ matrix.portal.name }}, C++${{ matrix.cppstd }}
+    name: Ubuntu ${{ matrix.os.name }} - ${{ matrix.compiler.name }}, ${{ matrix.portal.name }}, ${{ matrix.autoappend.name }}, C++${{ matrix.cppstd }}
     runs-on: ${{ matrix.os.label }}
 
     strategy:
       matrix:
         os: [ {label: ubuntu-latest, name: latest}, {label: ubuntu-18.04, name: 18.04} ]
         portal: [ {flag: OFF, dep: libgtk-3-dev, name: GTK}, {flag: ON, dep: libdbus-1-dev, name: Portal} ] # The NFD_PORTAL setting defaults to OFF (i.e. uses GTK)
+        autoappend: [ {flag: OFF, name: NoAppendExtn} ] # By default the NFD_PORTAL mode does not append extensions, because it breaks some features of the portal
         compiler: [ {c: gcc, cpp: g++, name: GCC}, {c: clang, cpp: clang++, name: Clang} ] # The default compiler is gcc/g++
         cppstd: [23, 11]
+        include:
+        - os: {label: ubuntu-latest, name: latest}
+          portal: {flag: ON, dep: libdbus-1-dev, name: Portal}
+          autoappend: {flag: ON, name: AutoAppendExtn}
+          compiler: {c: gcc, cpp: g++, name: GCC}
+          cppstd: 11
+        - os: {label: ubuntu-latest, name: latest}
+          portal: {flag: ON, dep: libdbus-1-dev, name: Portal}
+          autoappend: {flag: ON, name: AutoAppendExtn}
+          compiler: {c: clang, cpp: clang++, name: Clang}
+          cppstd: 11
 
     steps:
     - name: Checkout
@@ -38,13 +50,13 @@ jobs:
     - name: Installing Dependencies
       run: sudo apt-get update && sudo apt-get install ${{ matrix.portal.dep }}
     - name: Configure
-      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.compiler.c }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }} -DCMAKE_CXX_STANDARD=${{ matrix.cppstd }} -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_PORTAL=${{ matrix.portal.flag }} -DNFD_BUILD_TESTS=ON ..
+      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.compiler.c }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }} -DCMAKE_CXX_STANDARD=${{ matrix.cppstd }} -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_PORTAL=${{ matrix.portal.flag }} -DNFD_APPEND_EXTENSION=${{ matrix.autoappend.flag }} -DNFD_BUILD_TESTS=ON ..
     - name: Build
       run: cmake --build build --target install
     - name: Upload test binaries
       uses: actions/upload-artifact@v2
       with:
-        name: Ubuntu ${{ matrix.os.name }} - ${{ matrix.compiler.name }}, ${{ matrix.portal.name }}, C++${{ matrix.cppstd }}
+        name: Ubuntu ${{ matrix.os.name }} - ${{ matrix.compiler.name }}, ${{ matrix.portal.name }}, ${{ matrix.autoappend.name }}, C++${{ matrix.cppstd }}
         path: |
           build/src/libnfd.a
           build/test/test_*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,11 @@ if(nfd_PLATFORM STREQUAL PLATFORM_LINUX)
     target_compile_definitions(${TARGET_NAME}
       PUBLIC NFD_PORTAL)
   endif()
+
+  option(NFD_APPEND_EXTENSION "Automatically append file extension to an extensionless selection in SaveDialog()" OFF)
+  if(NFD_APPEND_EXTENSION)
+    target_compile_definitions(${TARGET_NAME} PRIVATE NFD_APPEND_EXTENSION)
+  endif()
 endif()
 
 if(nfd_PLATFORM STREQUAL PLATFORM_MACOS)

--- a/src/nfd_portal.cpp
+++ b/src/nfd_portal.cpp
@@ -20,13 +20,12 @@
 #include "nfd.h"
 
 /*
-Define NFD_PORTAL_AUTO_APPEND_FILE_EXTENSION to 0 if you don't want the file extension to be
-appended when missing. Linux programs usually doesn't append the file extension, but for consistency
-with other OSes we append it by default.
+Define NFD_APPEND_EXTENSION if you want the file extension to be appended when missing. Linux
+programs usually don't append the file extension, but for consistency with other OSes you might want
+to append it.  However, when using portals, the file overwrite prompt and the Flatpak sandbox won't
+know that we appended an extension, so they will not check or whitelist the correct file.  Enabling
+NFD_APPEND_EXTENSION is not recommended for portals.
 */
-#ifndef NFD_PORTAL_AUTO_APPEND_FILE_EXTENSION
-#define NFD_PORTAL_AUTO_APPEND_FILE_EXTENSION 1
-#endif
 
 namespace {
 
@@ -727,7 +726,7 @@ nfdresult_t ReadResponseUrisSingle(DBusMessage* msg, const char*& file) {
     return NFD_OKAY;
 }
 
-#if NFD_PORTAL_AUTO_APPEND_FILE_EXTENSION == 1
+#ifdef NFD_APPEND_EXTENSION
 // Read the response URI and selected extension (in the form "*.abc" or "*") (if any).  If response
 // was okay, then returns NFD_OKAY and set file and extn to them (the pointer is set to some string
 // owned by msg, so you should not manually free it).  `file` is the user-entered file name, and
@@ -1027,7 +1026,7 @@ nfdresult_t AllocAndCopyFilePath(const char* fileUri, char*& outPath) {
     return NFD_OKAY;
 }
 
-#if NFD_PORTAL_AUTO_APPEND_FILE_EXTENSION == 1
+#ifdef NFD_APPEND_EXTENSION
 bool TryGetValidExtension(const char* extn,
                           const char*& trimmed_extn,
                           const char*& trimmed_extn_end) {
@@ -1367,7 +1366,7 @@ nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
     }
     DBusMessage_Guard msg_guard(msg);
 
-#if NFD_PORTAL_AUTO_APPEND_FILE_EXTENSION == 1
+#ifdef NFD_APPEND_EXTENSION
     const char* uri;
     const char* extn;
     {


### PR DESCRIPTION
Automatically appending the file extension breaks portals because the overwrite prompt will check the wrong file, and the wrong file will be exposed to the sandboxed application.