### PR TITLE
ClangFormat: Force ClangFormat 13 for now

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Format code
-      run: find src/ test/ -iname '*.c' -or -iname '*.cpp' -or -iname '*.m' -or -iname '*.mm' -or -iname '*.h' -or -iname '*.hpp' | xargs clang-format -i -style=file
+      # ClangFormat 14 has a bug, which seems to be fixed in ClangFormat 15.  Until GitHub-hosted runners support ClangFormat 15, we will stay at ClangFormat 13.
+      run: find src/ test/ -iname '*.c' -or -iname '*.cpp' -or -iname '*.m' -or -iname '*.mm' -or -iname '*.h' -or -iname '*.hpp' | xargs clang-format-13 -i -style=file
     - name: Check diff
       run: git diff --exit-code
 


### PR DESCRIPTION
ClangFormat 14 formats this code incorrectly:
```
diff --git a/src/include/nfd.hpp b/src/include/nfd.hpp
index bbce108..21c4e1[5](https://github.com/btzy/nativefiledialog-extended/actions/runs/3893292193/jobs/6645716907#step:4:6) 100[6](https://github.com/btzy/nativefiledialog-extended/actions/runs/3893292193/jobs/6645716907#step:4:7)44
--- a/src/include/nfd.hpp
+++ b/src/include/nfd.hpp
@@ -151,[7](https://github.com/btzy/nativefiledialog-extended/actions/runs/3893292193/jobs/6645716907#step:4:8) +151,[9](https://github.com/btzy/nativefiledialog-extended/actions/runs/3893292193/jobs/6645716907#step:4:10) @@ class Guard {
         }
     }
 #endif
-    inline ~Guard() noexcept { Quit(); }
+    inline ~Guard() noexcept {
+        Quit();
+    }
 
     // Not allowed to copy or move this class
     Guard(const Guard&) = delete;
```

It seems that ClangFormat 15 formats it correctly again, so we will stay on ClangFormat 13 until GitHub-hosted runners gain ClangFormat 15.