### PR TITLE
Build: Use XXX_LINK_LIBRARIES for linking to support *BSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,12 +68,12 @@ if(nfd_PLATFORM STREQUAL PLATFORM_LINUX)
     target_include_directories(${TARGET_NAME}
       PRIVATE ${GTK3_INCLUDE_DIRS})
     target_link_libraries(${TARGET_NAME}
-      PRIVATE ${GTK3_LIBRARIES})
+      PRIVATE ${GTK3_LINK_LIBRARIES})
   else()
     target_include_directories(${TARGET_NAME}
       PRIVATE ${DBUS_INCLUDE_DIRS})
     target_link_libraries(${TARGET_NAME}
-      PRIVATE ${DBUS_LIBRARIES})
+      PRIVATE ${DBUS_LINK_LIBRARIES})
     target_compile_definitions(${TARGET_NAME}
       PUBLIC NFD_PORTAL)
   endif()


### PR DESCRIPTION
When gtk or dbus is installed on a non default location, for instance /usr/local for *BSD,
using XXX_LIBRARIES failed at link phase, while XXX_LINK_LIBRARIES always works.