### PR TITLE
Add `getrandom` fallback for versions of GLIBC < 2.25

### DIFF
--- a/src/nfd_portal.cpp
+++ b/src/nfd_portal.cpp
@@ -14,8 +14,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/random.h>  // for the random token string
-#include <unistd.h>      // for access()
+#include <unistd.h>  // for access()
+
+#if !defined(__has_include) || !defined(__linux__)
+#include <sys/random.h>  // for getrandom() - the random token string
+#elif __has_include(<sys/random.h>)
+#include <sys/random.h>
+#else  // for GLIBC < 2.25
+#include <sys/syscall.h>
+#define getrandom(buf, sz, flags) syscall(SYS_getrandom, buf, sz, flags)
+#endif
 
 #include "nfd.h"
 


### PR DESCRIPTION
When compiling against a version of GLIBC before 2.25, `getrandom` is not available, so this change provides a fallback to perform the relevant syscall directly.