### PR TITLE
CI: Upgrade Ubuntu 18.04 to Ubuntu 20.04

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ {label: ubuntu-latest, name: latest}, {label: ubuntu-18.04, name: 18.04} ]
+        os: [ {label: ubuntu-latest, name: latest}, {label: ubuntu-20.04, name: 20.04} ]
         portal: [ {flag: OFF, dep: libgtk-3-dev, name: GTK}, {flag: ON, dep: libdbus-1-dev, name: Portal} ] # The NFD_PORTAL setting defaults to OFF (i.e. uses GTK)
         autoappend: [ {flag: OFF, name: NoAppendExtn} ] # By default the NFD_PORTAL mode does not append extensions, because it breaks some features of the portal
         compiler: [ {c: gcc, cpp: g++, name: GCC}, {c: clang, cpp: clang++, name: Clang} ] # The default compiler is gcc/g++


### PR DESCRIPTION
GitHub Actions no longer supports Ubuntu 18.04 runners.  Since `ubuntu-latest` refers to Ubuntu 22.04, we don't currently test on Ubuntu 20.04, so we'll upgrade the Ubuntu 18.04 runners to Ubuntu 20.04.