### PR TITLE
Portal: Support formatted error messages using sprintf()

### DIFF
--- a/src/nfd_portal.cpp
+++ b/src/nfd_portal.cpp
@@ -77,7 +77,10 @@ struct DBusMessage_Guard {
 DBusConnection* dbus_conn;
 /* current D-Bus error */
 DBusError dbus_err;
-/* current error (may be a pointer to the D-Bus error message above, or a pointer to some string
+/* current non D-Bus error */
+constexpr size_t OWNED_ERR_LEN = 1024;
+char owned_err[OWNED_ERR_LEN]{};
+/* current error (may be a pointer to dbus_err.message, owned_err, or a pointer to some string
  * literal) */
 const char* err_ptr = nullptr;
 /* the unique name of our connection, used for the Request handle; owned by D-Bus so we don't free
@@ -86,6 +89,14 @@ const char* dbus_unique_name;
 
 void NFDi_SetError(const char* msg) {
     err_ptr = msg;
+}
+
+void NFDi_SetFormattedError(const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    vsnprintf(owned_err, OWNED_ERR_LEN, format, args);
+    va_end(args);
+    err_ptr = owned_err;
 }
 
 template <typename T>
@@ -119,6 +130,10 @@ constexpr const char* STR_CURRENT_FOLDER = "current_folder";
 constexpr const char* STR_CURRENT_FILE = "current_file";
 constexpr const char* STR_ALL_FILES = "All files";
 constexpr const char* STR_ASTERISK = "*";
+constexpr const char* DBUS_DESTINATION = "org.freedesktop.portal.Desktop";
+constexpr const char* DBUS_PATH = "/org/freedesktop/portal/desktop";
+constexpr const char* DBUS_FILECHOOSER_IFACE = "org.freedesktop.portal.FileChooser";
+constexpr const char* DBUS_REQUEST_IFACE = "org.freedesktop.portal.Request";
 
 template <bool Multiple, bool Directory>
 void AppendOpenFileQueryTitle(DBusMessageIter&);
@@ -656,7 +671,9 @@ nfdresult_t ReadResponseResults(DBusMessage* msg, DBusMessageIter& resultsIter) 
             return NFD_CANCEL;
         } else {
             // Some error occurred
-            NFDi_SetError("D-Bus file dialog interaction was ended abruptly.");
+            NFDi_SetFormattedError(
+                "D-Bus file dialog interaction was ended abruptly with response code %u.",
+                resp_code);
             return NFD_ERROR;
         }
     }
@@ -770,47 +787,37 @@ nfdresult_t ReadResponseUrisSingleAndCurrentExtension(DBusMessage* msg,
             [&tmp_extn](DBusMessageIter& current_filter_iter) {
                 // current_filter is best_effort, so if we fail, we still return NFD_OKAY.
                 if (dbus_message_iter_get_arg_type(&current_filter_iter) != DBUS_TYPE_STRUCT) {
-                    // NFDi_SetError("D-Bus response signal current_filter iter is not a struct.");
                     return NFD_OKAY;
                 }
                 DBusMessageIter current_filter_struct_iter;
                 dbus_message_iter_recurse(&current_filter_iter, &current_filter_struct_iter);
                 if (!dbus_message_iter_next(&current_filter_struct_iter)) {
-                    // NFDi_SetError("D-Bus response signal current_filter struct iter ended
-                    // prematurely.");
                     return NFD_OKAY;
                 }
                 if (dbus_message_iter_get_arg_type(&current_filter_struct_iter) !=
                     DBUS_TYPE_ARRAY) {
-                    // NFDi_SetError("D-Bus response signal URI sub iter is not a string.");
                     return NFD_OKAY;
                 }
                 DBusMessageIter current_filter_array_iter;
                 dbus_message_iter_recurse(&current_filter_struct_iter, &current_filter_array_iter);
                 if (dbus_message_iter_get_arg_type(&current_filter_array_iter) !=
                     DBUS_TYPE_STRUCT) {
-                    // NFDi_SetError("D-Bus response signal current_filter iter is not a struct.");
                     return NFD_OKAY;
                 }
                 DBusMessageIter current_filter_extn_iter;
                 dbus_message_iter_recurse(&current_filter_array_iter, &current_filter_extn_iter);
                 if (dbus_message_iter_get_arg_type(&current_filter_extn_iter) != DBUS_TYPE_UINT32) {
-                    // NFDi_SetError("D-Bus response signal URI sub iter is not a string.");
                     return NFD_OKAY;
                 }
                 dbus_uint32_t type;
                 dbus_message_iter_get_basic(&current_filter_extn_iter, &type);
                 if (type != 0) {
-                    // NFDi_SetError("Wrong filter type.");
                     return NFD_OKAY;
                 }
                 if (!dbus_message_iter_next(&current_filter_extn_iter)) {
-                    // NFDi_SetError("D-Bus response signal current_filter struct iter ended
-                    // prematurely.");
                     return NFD_OKAY;
                 }
                 if (dbus_message_iter_get_arg_type(&current_filter_extn_iter) != DBUS_TYPE_STRING) {
-                    // NFDi_SetError("D-Bus response signal URI sub iter is not a string.");
                     return NFD_OKAY;
                 }
                 dbus_message_iter_get_basic(&current_filter_extn_iter, &tmp_extn);
@@ -1013,22 +1020,25 @@ constexpr size_t FILE_URI_PREFIX_LEN = sizeof(FILE_URI_PREFIX) - 1;
 // buffer, and make outPath point to it, and returns NFD_OKAY. Otherwise, does not modify outPath
 // and returns NFD_ERROR (with the correct error set)
 nfdresult_t AllocAndCopyFilePath(const char* fileUri, char*& outPath) {
+    const char* file_uri_iter = fileUri;
     const char* prefix_begin = FILE_URI_PREFIX;
     const char* const prefix_end = FILE_URI_PREFIX + FILE_URI_PREFIX_LEN;
-    for (; prefix_begin != prefix_end; ++prefix_begin, ++fileUri) {
-        if (*prefix_begin != *fileUri) {
-            NFDi_SetError("D-Bus freedesktop portal returned a URI that is not a file URI.");
+    for (; prefix_begin != prefix_end; ++prefix_begin, ++file_uri_iter) {
+        if (*prefix_begin != *file_uri_iter) {
+            NFDi_SetFormattedError(
+                "D-Bus freedesktop portal returned \"%s\", which is not a file URI.", fileUri);
             return NFD_ERROR;
         }
     }
     size_t decoded_len;
     const char* file_uri_end;
-    if (!TryUriDecodeLen(fileUri, decoded_len, file_uri_end)) {
-        NFDi_SetError("D-Bus freedesktop portal returned a malformed URI.");
+    if (!TryUriDecodeLen(file_uri_iter, decoded_len, file_uri_end)) {
+        NFDi_SetFormattedError("D-Bus freedesktop portal returned a malformed URI \"%s\".",
+                               fileUri);
         return NFD_ERROR;
     }
     char* const path_without_prefix = NFDi_Malloc<char>(decoded_len + 1);
-    char* const out_end = UriDecodeUnchecked(fileUri, file_uri_end, path_without_prefix);
+    char* const out_end = UriDecodeUnchecked(file_uri_iter, file_uri_end, path_without_prefix);
     *out_end = '\0';
     outPath = path_without_prefix;
     return NFD_OKAY;
@@ -1055,19 +1065,22 @@ bool TryGetValidExtension(const char* extn,
 // expected to be either in the form "*.abc" or "*", but this function will check for it, and ignore
 // the extension if it is not in the correct form.
 nfdresult_t AllocAndCopyFilePathWithExtn(const char* fileUri, const char* extn, char*& outPath) {
+    const char* file_uri_iter = fileUri;
     const char* prefix_begin = FILE_URI_PREFIX;
     const char* const prefix_end = FILE_URI_PREFIX + FILE_URI_PREFIX_LEN;
-    for (; prefix_begin != prefix_end; ++prefix_begin, ++fileUri) {
-        if (*prefix_begin != *fileUri) {
-            NFDi_SetError("D-Bus freedesktop portal returned a URI that is not a file URI.");
+    for (; prefix_begin != prefix_end; ++prefix_begin, ++file_uri_iter) {
+        if (*prefix_begin != *file_uri_iter) {
+            NFDi_SetFormattedError(
+                "D-Bus freedesktop portal returned \"%s\", which is not a file URI.", fileUri);
             return NFD_ERROR;
         }
     }
 
     size_t decoded_len;
     const char* file_uri_end;
-    if (!TryUriDecodeLen(fileUri, decoded_len, file_uri_end)) {
-        NFDi_SetError("D-Bus freedesktop portal returned a malformed URI.");
+    if (!TryUriDecodeLen(file_uri_iter, decoded_len, file_uri_end)) {
+        NFDi_SetFormattedError("D-Bus freedesktop portal returned a malformed URI \"%s\".",
+                               fileUri);
         return NFD_ERROR;
     }
 
@@ -1084,14 +1097,14 @@ nfdresult_t AllocAndCopyFilePathWithExtn(const char* fileUri, const char* extn, 
     if (*file_it == '.' || !TryGetValidExtension(extn, trimmed_extn, trimmed_extn_end)) {
         // has file extension already or no valid extension in `extn`
         char* const path_without_prefix = NFDi_Malloc<char>(decoded_len + 1);
-        char* const out_end = UriDecodeUnchecked(fileUri, file_uri_end, path_without_prefix);
+        char* const out_end = UriDecodeUnchecked(file_uri_iter, file_uri_end, path_without_prefix);
         *out_end = '\0';
         outPath = path_without_prefix;
     } else {
         // no file extension and we have a valid extension
         char* const path_without_prefix =
             NFDi_Malloc<char>(decoded_len + (trimmed_extn_end - trimmed_extn));
-        char* const out_mid = UriDecodeUnchecked(fileUri, file_uri_end, path_without_prefix);
+        char* const out_mid = UriDecodeUnchecked(file_uri_iter, file_uri_end, path_without_prefix);
         char* const out_end = copy(trimmed_extn, trimmed_extn_end, out_mid);
         *out_end = '\0';
         outPath = path_without_prefix;
@@ -1124,10 +1137,8 @@ nfdresult_t NFD_DBus_OpenFile(DBusMessage*& outMsg,
     // TODO: use XOpenDisplay()/XGetInputFocus() to find xid of window... but what should one do on
     // Wayland?
 
-    DBusMessage* query = dbus_message_new_method_call("org.freedesktop.portal.Desktop",
-                                                      "/org/freedesktop/portal/desktop",
-                                                      "org.freedesktop.portal.FileChooser",
-                                                      "OpenFile");
+    DBusMessage* query = dbus_message_new_method_call(
+        DBUS_DESTINATION, DBUS_PATH, DBUS_FILECHOOSER_IFACE, "OpenFile");
     DBusMessage_Guard query_guard(query);
     AppendOpenFileQueryParams<Multiple, Directory>(
         query, handle_token_ptr, filterList, filterCount);
@@ -1169,7 +1180,7 @@ nfdresult_t NFD_DBus_OpenFile(DBusMessage*& outMsg,
             DBusMessage* msg = dbus_connection_pop_message(dbus_conn);
             if (!msg) break;
 
-            if (dbus_message_is_signal(msg, "org.freedesktop.portal.Request", "Response")) {
+            if (dbus_message_is_signal(msg, DBUS_REQUEST_IFACE, "Response")) {
                 // this is the response we're looking for
                 outMsg = msg;
                 return NFD_OKAY;
@@ -1208,10 +1219,8 @@ nfdresult_t NFD_DBus_SaveFile(DBusMessage*& outMsg,
     // TODO: use XOpenDisplay()/XGetInputFocus() to find xid of window... but what should one do on
     // Wayland?
 
-    DBusMessage* query = dbus_message_new_method_call("org.freedesktop.portal.Desktop",
-                                                      "/org/freedesktop/portal/desktop",
-                                                      "org.freedesktop.portal.FileChooser",
-                                                      "SaveFile");
+    DBusMessage* query = dbus_message_new_method_call(
+        DBUS_DESTINATION, DBUS_PATH, DBUS_FILECHOOSER_IFACE, "SaveFile");
     DBusMessage_Guard query_guard(query);
     AppendSaveFileQueryParams(
         query, handle_token_ptr, filterList, filterCount, defaultPath, defaultName);
@@ -1253,7 +1262,7 @@ nfdresult_t NFD_DBus_SaveFile(DBusMessage*& outMsg,
             DBusMessage* msg = dbus_connection_pop_message(dbus_conn);
             if (!msg) break;
 
-            if (dbus_message_is_signal(msg, "org.freedesktop.portal.Request", "Response")) {
+            if (dbus_message_is_signal(msg, DBUS_REQUEST_IFACE, "Response")) {
                 // this is the response we're looking for
                 outMsg = msg;
                 return NFD_OKAY;
@@ -1281,7 +1290,7 @@ void NFD_ClearError(void) {
 }
 
 nfdresult_t NFD_Init(void) {
-    // Initialize dbus_error
+    // Initialize dbus_err
     dbus_error_init(&dbus_err);
     // Get DBus connection
     dbus_conn = dbus_bus_get(DBUS_BUS_SESSION, &dbus_err);
@@ -1435,10 +1444,15 @@ nfdresult_t NFD_PathSet_GetPathN(const nfdpathset_t* pathSet,
     DBusMessage* msg = const_cast<DBusMessage*>(static_cast<const DBusMessage*>(pathSet));
     DBusMessageIter uri_iter;
     ReadResponseUrisUnchecked(msg, uri_iter);
-    while (index > 0) {
-        --index;
+    nfdpathsetsize_t rem_index = index;
+    while (rem_index > 0) {
+        --rem_index;
         if (!dbus_message_iter_next(&uri_iter)) {
-            NFDi_SetError("Index out of bounds.");
+            NFDi_SetFormattedError(
+                "Index out of bounds; you asked for index %u but there are only %u file paths "
+                "available.",
+                index,
+                index - rem_index);
             return NFD_ERROR;
         }
     }


### PR DESCRIPTION
It is not always possible to provide a good error message with a hardcoded string, because additional runtime information might be useful.  This PR adds `NFDi_SetFormattedError()`, that can be used in place of `NFDi_SetError()` and calls `vsprintf()` internally.