### PR TITLE
Add support for building shared libraries on Windows

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Configure
-      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DBUILD_SHARED_LIBS=${{ matrix.shared_lib.flag }} -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=${{ matrix.shared_lib.flag }} -DNFD_BUILD_TESTS=ON ..
+      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DBUILD_SHARED_LIBS=${{ matrix.shared_lib.flag }} -DNFD_BUILD_TESTS=ON ..
     - name: Build
       run: cmake --build build --target install --config Release
     - name: Upload test binaries

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,10 @@ endif()
 # Define the library
 add_library(${TARGET_NAME} ${SOURCE_FILES})
 
+if (BUILD_SHARED_LIBS)
+  target_compile_definitions(${TARGET_NAME} PRIVATE NFD_EXPORT INTERFACE NFD_SHARED)
+endif ()
+
 # Allow includes from include/
 target_include_directories(${TARGET_NAME}
   PUBLIC

--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -10,24 +10,22 @@
 #ifndef _NFD_H
 #define _NFD_H
 
-
 #if defined(_WIN32)
-#  if defined(NFD_EXPORT)
-#    define NFD_API __declspec(dllexport)
-#  elif defined(NFD_SHARED)
-#    define NFD_API __declspec(dllimport)
-#  endif
+#if defined(NFD_EXPORT)
+#define NFD_API __declspec(dllexport)
+#elif defined(NFD_SHARED)
+#define NFD_API __declspec(dllimport)
+#endif
 #else
-#  if defined(NFD_EXPORT) || defined(NFD_SHARED)
-#    if defined(__GNUC__) || defined(__clang__)
-#      define NFD_API __attribute__((visibility("default")))
-#    endif
-#  endif
+#if defined(NFD_EXPORT) || defined(NFD_SHARED)
+#if defined(__GNUC__) || defined(__clang__)
+#define NFD_API __attribute__((visibility("default")))
+#endif
+#endif
 #endif
 #ifndef NFD_API
-#  define NFD_API
+#define NFD_API
 #endif
-
 
 #ifdef __cplusplus
 extern "C" {
@@ -98,9 +96,9 @@ NFD_API void NFD_Quit(void);
 /* If filterCount is zero, filterList is ignored (you can use NULL) */
 /* If defaultPath is NULL, the operating system will decide */
 NFD_API nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
-                            const nfdnfilteritem_t* filterList,
-                            nfdfiltersize_t filterCount,
-                            const nfdnchar_t* defaultPath);
+                                    const nfdnfilteritem_t* filterList,
+                                    nfdfiltersize_t filterCount,
+                                    const nfdnchar_t* defaultPath);
 
 /* multiple file open dialog */
 /* It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
@@ -108,9 +106,9 @@ NFD_API nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
 /* If filterCount is zero, filterList is ignored (you can use NULL) */
 /* If defaultPath is NULL, the operating system will decide */
 NFD_API nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
-                                    const nfdnfilteritem_t* filterList,
-                                    nfdfiltersize_t filterCount,
-                                    const nfdnchar_t* defaultPath);
+                                            const nfdnfilteritem_t* filterList,
+                                            nfdfiltersize_t filterCount,
+                                            const nfdnchar_t* defaultPath);
 
 /* save dialog */
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathN() if this function returns
@@ -118,10 +116,10 @@ NFD_API nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
 /* If filterCount is zero, filterList is ignored (you can use NULL) */
 /* If defaultPath is NULL, the operating system will decide */
 NFD_API nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
-                            const nfdnfilteritem_t* filterList,
-                            nfdfiltersize_t filterCount,
-                            const nfdnchar_t* defaultPath,
-                            const nfdnchar_t* defaultName);
+                                    const nfdnfilteritem_t* filterList,
+                                    nfdfiltersize_t filterCount,
+                                    const nfdnchar_t* defaultPath,
+                                    const nfdnchar_t* defaultName);
 
 /* select folder dialog */
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathN() if this function returns
@@ -155,8 +153,8 @@ NFD_API nfdresult_t NFD_PathSet_GetCount(const nfdpathset_t* pathSet, nfdpathset
 /* It is the caller's responsibility to free `outPath` via NFD_PathSet_FreePathN() if this function
  * returns NFD_OKAY */
 NFD_API nfdresult_t NFD_PathSet_GetPathN(const nfdpathset_t* pathSet,
-                                 nfdpathsetsize_t index,
-                                 nfdnchar_t** outPath);
+                                         nfdpathsetsize_t index,
+                                         nfdnchar_t** outPath);
 /* Free the path gotten by NFD_PathSet_GetPathN */
 #ifdef _WIN32
 #define NFD_PathSet_FreePathN NFD_FreePathN
@@ -169,7 +167,8 @@ NFD_API void NFD_PathSet_FreePathN(const nfdnchar_t* filePath);
 /* Gets an enumerator of the path set. */
 /* It is the caller's responsibility to free `enumerator` via NFD_PathSet_FreeEnum() if this
  * function returns NFD_OKAY, and it should be freed before freeing the pathset. */
-NFD_API nfdresult_t NFD_PathSet_GetEnum(const nfdpathset_t* pathSet, nfdpathsetenum_t* outEnumerator);
+NFD_API nfdresult_t NFD_PathSet_GetEnum(const nfdpathset_t* pathSet,
+                                        nfdpathsetenum_t* outEnumerator);
 /* Frees an enumerator of the path set. */
 NFD_API void NFD_PathSet_FreeEnum(nfdpathsetenum_t* enumerator);
 /* Gets the next item from the path set enumerator.
@@ -202,26 +201,26 @@ NFD_API void NFD_FreePathU8(nfdu8char_t* outPath);
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function returns
  * NFD_OKAY */
 NFD_API nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
-                             const nfdu8filteritem_t* filterList,
-                             nfdfiltersize_t count,
-                             const nfdu8char_t* defaultPath);
+                                     const nfdu8filteritem_t* filterList,
+                                     nfdfiltersize_t count,
+                                     const nfdu8char_t* defaultPath);
 
 /* multiple file open dialog */
 /* It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
  * returns NFD_OKAY */
 NFD_API nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
-                                     const nfdu8filteritem_t* filterList,
-                                     nfdfiltersize_t count,
-                                     const nfdu8char_t* defaultPath);
+                                             const nfdu8filteritem_t* filterList,
+                                             nfdfiltersize_t count,
+                                             const nfdu8char_t* defaultPath);
 
 /* save dialog */
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function returns
  * NFD_OKAY */
 NFD_API nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
-                             const nfdu8filteritem_t* filterList,
-                             nfdfiltersize_t count,
-                             const nfdu8char_t* defaultPath,
-                             const nfdu8char_t* defaultName);
+                                     const nfdu8filteritem_t* filterList,
+                                     nfdfiltersize_t count,
+                                     const nfdu8char_t* defaultPath,
+                                     const nfdu8char_t* defaultName);
 
 /* select folder dialog */
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function returns
@@ -232,8 +231,8 @@ NFD_API nfdresult_t NFD_PickFolderU8(nfdu8char_t** outPath, const nfdu8char_t* d
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function returns
  * NFD_OKAY */
 NFD_API nfdresult_t NFD_PathSet_GetPathU8(const nfdpathset_t* pathSet,
-                                  nfdpathsetsize_t index,
-                                  nfdu8char_t** outPath);
+                                          nfdpathsetsize_t index,
+                                          nfdu8char_t** outPath);
 
 /* Gets the next item from the path set enumerator.
  * If there are no more items, then *outPaths will be set to NULL. */

--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -10,6 +10,25 @@
 #ifndef _NFD_H
 #define _NFD_H
 
+
+#if defined(_WIN32)
+#  if defined(NFD_EXPORT)
+#    define NFD_API __declspec(dllexport)
+#  elif defined(NFD_SHARED)
+#    define NFD_API __declspec(dllimport)
+#  endif
+#else
+#  if defined(NFD_EXPORT) || defined(NFD_SHARED)
+#    if defined(__GNUC__) || defined(__clang__)
+#      define NFD_API __attribute__((visibility("default")))
+#    endif
+#  endif
+#endif
+#ifndef NFD_API
+#  define NFD_API
+#endif
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -64,21 +83,21 @@ typedef struct {
 
 /* free a file path that was returned by the dialogs */
 /* Note: use NFD_PathSet_FreePath to free path from pathset instead of this function */
-void NFD_FreePathN(nfdnchar_t* filePath);
+NFD_API void NFD_FreePathN(nfdnchar_t* filePath);
 
 /* initialize NFD - call this for every thread that might use NFD, before calling any other NFD
  * functions on that thread */
-nfdresult_t NFD_Init(void);
+NFD_API nfdresult_t NFD_Init(void);
 
 /* call this to de-initialize NFD, if NFD_Init returned NFD_OKAY */
-void NFD_Quit(void);
+NFD_API void NFD_Quit(void);
 
 /* single file open dialog */
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathN() if this function returns
  * NFD_OKAY */
 /* If filterCount is zero, filterList is ignored (you can use NULL) */
 /* If defaultPath is NULL, the operating system will decide */
-nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
+NFD_API nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
                             const nfdnfilteritem_t* filterList,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath);
@@ -88,7 +107,7 @@ nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
  * returns NFD_OKAY */
 /* If filterCount is zero, filterList is ignored (you can use NULL) */
 /* If defaultPath is NULL, the operating system will decide */
-nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
+NFD_API nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
                                     const nfdnfilteritem_t* filterList,
                                     nfdfiltersize_t filterCount,
                                     const nfdnchar_t* defaultPath);
@@ -98,7 +117,7 @@ nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
  * NFD_OKAY */
 /* If filterCount is zero, filterList is ignored (you can use NULL) */
 /* If defaultPath is NULL, the operating system will decide */
-nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
+NFD_API nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
                             const nfdnfilteritem_t* filterList,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath,
@@ -108,16 +127,16 @@ nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathN() if this function returns
  * NFD_OKAY */
 /* If defaultPath is NULL, the operating system will decide */
-nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath);
+NFD_API nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath);
 
 /* Get last error -- set when nfdresult_t returns NFD_ERROR */
 /* Returns the last error that was set, or NULL if there is no error. */
 /* The memory is owned by NFD and should not be freed by user code. */
 /* This is *always* ASCII printable characters, so it can be interpreted as UTF-8 without any
  * conversion. */
-const char* NFD_GetError(void);
+NFD_API const char* NFD_GetError(void);
 /* clear the error */
-void NFD_ClearError(void);
+NFD_API void NFD_ClearError(void);
 
 /* path set operations */
 #ifdef _WIN32
@@ -131,11 +150,11 @@ typedef unsigned int nfdpathsetsize_t;
 /* Gets the number of entries stored in pathSet */
 /* note that some paths might be invalid (NFD_ERROR will be returned by NFD_PathSet_GetPath), so we
  * might not actually have this number of usable paths */
-nfdresult_t NFD_PathSet_GetCount(const nfdpathset_t* pathSet, nfdpathsetsize_t* count);
+NFD_API nfdresult_t NFD_PathSet_GetCount(const nfdpathset_t* pathSet, nfdpathsetsize_t* count);
 /* Gets the UTF-8 path at offset index */
 /* It is the caller's responsibility to free `outPath` via NFD_PathSet_FreePathN() if this function
  * returns NFD_OKAY */
-nfdresult_t NFD_PathSet_GetPathN(const nfdpathset_t* pathSet,
+NFD_API nfdresult_t NFD_PathSet_GetPathN(const nfdpathset_t* pathSet,
                                  nfdpathsetsize_t index,
                                  nfdnchar_t** outPath);
 /* Free the path gotten by NFD_PathSet_GetPathN */
@@ -144,23 +163,23 @@ nfdresult_t NFD_PathSet_GetPathN(const nfdpathset_t* pathSet,
 #elif __APPLE__
 #define NFD_PathSet_FreePathN NFD_FreePathN
 #else
-void NFD_PathSet_FreePathN(const nfdnchar_t* filePath);
+NFD_API void NFD_PathSet_FreePathN(const nfdnchar_t* filePath);
 #endif  // _WIN32, __APPLE__
 
 /* Gets an enumerator of the path set. */
 /* It is the caller's responsibility to free `enumerator` via NFD_PathSet_FreeEnum() if this
  * function returns NFD_OKAY, and it should be freed before freeing the pathset. */
-nfdresult_t NFD_PathSet_GetEnum(const nfdpathset_t* pathSet, nfdpathsetenum_t* outEnumerator);
+NFD_API nfdresult_t NFD_PathSet_GetEnum(const nfdpathset_t* pathSet, nfdpathsetenum_t* outEnumerator);
 /* Frees an enumerator of the path set. */
-void NFD_PathSet_FreeEnum(nfdpathsetenum_t* enumerator);
+NFD_API void NFD_PathSet_FreeEnum(nfdpathsetenum_t* enumerator);
 /* Gets the next item from the path set enumerator.
  * If there are no more items, then *outPaths will be set to NULL. */
 /* It is the caller's responsibility to free `*outPath` via NFD_PathSet_FreePath() if this
  * function returns NFD_OKAY and `*outPath` is not null */
-nfdresult_t NFD_PathSet_EnumNextN(nfdpathsetenum_t* enumerator, nfdnchar_t** outPath);
+NFD_API nfdresult_t NFD_PathSet_EnumNextN(nfdpathsetenum_t* enumerator, nfdnchar_t** outPath);
 
 /* Free the pathSet */
-void NFD_PathSet_Free(const nfdpathset_t* pathSet);
+NFD_API void NFD_PathSet_Free(const nfdpathset_t* pathSet);
 
 #ifdef _WIN32
 
@@ -177,12 +196,12 @@ typedef struct {
 /* UTF-8 compatibility functions */
 
 /* free a file path that was returned */
-void NFD_FreePathU8(nfdu8char_t* outPath);
+NFD_API void NFD_FreePathU8(nfdu8char_t* outPath);
 
 /* single file open dialog */
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function returns
  * NFD_OKAY */
-nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
+NFD_API nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
                              const nfdu8filteritem_t* filterList,
                              nfdfiltersize_t count,
                              const nfdu8char_t* defaultPath);
@@ -190,7 +209,7 @@ nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
 /* multiple file open dialog */
 /* It is the caller's responsibility to free `outPaths` via NFD_PathSet_Free() if this function
  * returns NFD_OKAY */
-nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
+NFD_API nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
                                      const nfdu8filteritem_t* filterList,
                                      nfdfiltersize_t count,
                                      const nfdu8char_t* defaultPath);
@@ -198,7 +217,7 @@ nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
 /* save dialog */
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function returns
  * NFD_OKAY */
-nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
+NFD_API nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
                              const nfdu8filteritem_t* filterList,
                              nfdfiltersize_t count,
                              const nfdu8char_t* defaultPath,
@@ -207,12 +226,12 @@ nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
 /* select folder dialog */
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function returns
  * NFD_OKAY */
-nfdresult_t NFD_PickFolderU8(nfdu8char_t** outPath, const nfdu8char_t* defaultPath);
+NFD_API nfdresult_t NFD_PickFolderU8(nfdu8char_t** outPath, const nfdu8char_t* defaultPath);
 
 /* Get the UTF-8 path at offset index */
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function returns
  * NFD_OKAY */
-nfdresult_t NFD_PathSet_GetPathU8(const nfdpathset_t* pathSet,
+NFD_API nfdresult_t NFD_PathSet_GetPathU8(const nfdpathset_t* pathSet,
                                   nfdpathsetsize_t index,
                                   nfdu8char_t** outPath);
 
@@ -220,7 +239,7 @@ nfdresult_t NFD_PathSet_GetPathU8(const nfdpathset_t* pathSet,
  * If there are no more items, then *outPaths will be set to NULL. */
 /* It is the caller's responsibility to free `*outPath` via NFD_PathSet_FreePathU8() if this
  * function returns NFD_OKAY and `*outPath` is not null */
-nfdresult_t NFD_PathSet_EnumNextU8(nfdpathsetenum_t* enumerator, nfdu8char_t** outPath);
+NFD_API nfdresult_t NFD_PathSet_EnumNextU8(nfdpathsetenum_t* enumerator, nfdu8char_t** outPath);
 
 #define NFD_PathSet_FreePathU8 NFD_FreePathU8
 


### PR DESCRIPTION
If CMake is configured to create a shared library (.dll) for this library, the symbols (function names) are not exported and an empty dll file is created.
On Windows, the compiler has to be invited explicitly by the programmer to export (or import) a function from a shared library (e.g. using `__declspec(dllexport)` attributes...
It is common to define a LIBRARY_NAME_API macro for this purpose and prefix it to any publicly visible function declaration.

This PR adds support for this convention.
