### PR TITLE
Update minimum cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 project(nativefiledialog-extended VERSION 1.1.0)
 
 set(nfd_ROOT_PROJECT OFF)


### PR DESCRIPTION
Support for CMake versions lower than 3.5 have been deprecated with the newer versions of CMake. Thus a warning is being printed to the console now when configuring projects that use nativefiledialog-extended:

```
CMake Deprecation Warning at lib/third_party/nativefiledialog/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

This PR updates the minimum required cmake version to 3.5. Seeing that this version came out almost 8 years ago, this shouldn't affect most projects depending on this library.