### PR TITLE
CI: Make Clang on Ubuntu use libc++ instead of libstdc++

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ {label: ubuntu-latest, name: latest}, {label: ubuntu-20.04, name: 20.04} ]
         portal: [ {flag: OFF, dep: libgtk-3-dev, name: GTK}, {flag: ON, dep: libdbus-1-dev, name: Portal} ] # The NFD_PORTAL setting defaults to OFF (i.e. uses GTK)
         autoappend: [ {flag: OFF, name: NoAppendExtn} ] # By default the NFD_PORTAL mode does not append extensions, because it breaks some features of the portal
-        compiler: [ {c: gcc, cpp: g++, name: GCC}, {c: clang, cpp: clang++, name: Clang} ] # The default compiler is gcc/g++
+        compiler: [ {c: gcc, cpp: g++, name: GCC}, {c: clang-14, cpp: clang++-14, name: Clang, extra: -stdlib=libc++ -v, dep: clang-14 clang++-14 libc++-14-dev} ] # The default compiler is gcc/g++
         cppstd: [23, 11]
         shared_lib: [ {flag: OFF, name: Static} ]
         include:
@@ -58,9 +58,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Installing Dependencies
-      run: sudo apt-get update && sudo apt-get install ${{ matrix.portal.dep }}
+      run: sudo apt-get update && sudo apt-get install ${{ matrix.portal.dep }} ${{ matrix.compiler.dep }}
     - name: Configure
-      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.compiler.c }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }} -DCMAKE_CXX_STANDARD=${{ matrix.cppstd }} -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_PORTAL=${{ matrix.portal.flag }} -DNFD_APPEND_EXTENSION=${{ matrix.autoappend.flag }} -DBUILD_SHARED_LIBS=${{ matrix.shared_lib.flag }} -DNFD_BUILD_TESTS=ON ..
+      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.compiler.c }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }} -DCMAKE_CXX_STANDARD=${{ matrix.cppstd }} -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic ${{ matrix.compiler.extra }}" -DNFD_PORTAL=${{ matrix.portal.flag }} -DNFD_APPEND_EXTENSION=${{ matrix.autoappend.flag }} -DBUILD_SHARED_LIBS=${{ matrix.shared_lib.flag }} -DNFD_BUILD_TESTS=ON ..
     - name: Build
       run: cmake --build build --target install
     - name: Upload test binaries


### PR DESCRIPTION
Clang doesn't compile with libstdc++ when using -std=c++23.