### PR TITLE
CI: Downgrade from C++23 to C++20 on Ubuntu

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,7 +32,7 @@ jobs:
         portal: [ {flag: OFF, dep: libgtk-3-dev, name: GTK}, {flag: ON, dep: libdbus-1-dev, name: Portal} ] # The NFD_PORTAL setting defaults to OFF (i.e. uses GTK)
         autoappend: [ {flag: OFF, name: NoAppendExtn} ] # By default the NFD_PORTAL mode does not append extensions, because it breaks some features of the portal
         compiler: [ {c: gcc, cpp: g++, name: GCC}, {c: clang, cpp: clang++, name: Clang} ] # The default compiler is gcc/g++
-        cppstd: [23, 11]
+        cppstd: [20, 11]
         shared_lib: [ {flag: OFF, name: Static} ]
         include:
         - os: {label: ubuntu-latest, name: latest}


### PR DESCRIPTION
Clang is unable to compile some libstdc++ headers in C++23 mode.