### PR TITLE
Add versioned API

### DIFF
--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -29,6 +29,9 @@
 
 #ifdef __cplusplus
 extern "C" {
+#define NFD_INLINE inline
+#else
+#define NFD_INLINE static inline
 #endif  // __cplusplus
 
 #include <stddef.h>
@@ -93,6 +96,59 @@ typedef struct {
 typedef nfdu8filteritem_t nfdnfilteritem_t;
 #endif  // _WIN32
 
+typedef size_t nfdversion_t;
+
+typedef struct {
+    const nfdu8filteritem_t* filterList;
+    nfdfiltersize_t filterCount;
+    const nfdu8char_t* defaultPath;
+} nfdopendialogu8args_t;
+
+#ifdef _WIN32
+typedef struct {
+    const nfdnfilteritem_t* filterList;
+    nfdfiltersize_t filterCount;
+    const nfdnchar_t* defaultPath;
+} nfdopendialognargs_t;
+#else
+typedef nfdopendialogu8args_t nfdopendialognargs_t;
+#endif  // _WIN32
+
+typedef struct {
+    const nfdu8filteritem_t* filterList;
+    nfdfiltersize_t filterCount;
+    const nfdu8char_t* defaultPath;
+    const nfdu8char_t* defaultName;
+} nfdsavedialogu8args_t;
+
+#ifdef _WIN32
+typedef struct {
+    const nfdnfilteritem_t* filterList;
+    nfdfiltersize_t filterCount;
+    const nfdnchar_t* defaultPath;
+    const nfdnchar_t* defaultName;
+} nfdsavedialognargs_t;
+#else
+typedef nfdsavedialogu8args_t nfdsavedialognargs_t;
+#endif  // _WIN32
+
+typedef struct {
+    const nfdu8char_t* defaultPath;
+} nfdpickfolderu8args_t;
+
+#ifdef _WIN32
+typedef struct {
+    const nfdnchar_t* defaultPath;
+} nfdpickfoldernargs_t;
+#else
+typedef nfdpickfolderu8args_t nfdpickfoldernargs_t;
+#endif  // _WIN32
+
+// This is a unique identifier tagged to all the NFD_*With() function calls, for backward
+// compatibility purposes.  There is usually no need to use this directly, unless you want to use
+// NFD differently depending on the version you're building with.
+#define NFD_INTERFACE_VERSION 1
+
 /** Free a file path that was returned by the dialogs.
  *
  *  Note: use NFD_PathSet_FreePathN() to free path from pathset instead of this function. */
@@ -134,6 +190,35 @@ NFD_API nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
                                      nfdfiltersize_t filterCount,
                                      const nfdu8char_t* defaultPath);
 
+/** This function is a library implementation detail.  Please use NFD_OpenDialogN_With() instead. */
+NFD_API nfdresult_t NFD_OpenDialogN_With_Impl(nfdversion_t version,
+                                              nfdnchar_t** outPath,
+                                              const nfdopendialognargs_t* args);
+
+/** Single file open dialog, with additional parameters.
+ *
+ *  It is the caller's responsibility to free `outPath` via NFD_FreePathN() if this function
+ *  returns NFD_OKAY.  See documentation of nfdopendialognargs_t for details. */
+NFD_INLINE nfdresult_t NFD_OpenDialogN_With(nfdnchar_t** outPath,
+                                            const nfdopendialognargs_t* args) {
+    return NFD_OpenDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, args);
+}
+
+/** This function is a library implementation detail.  Please use NFD_OpenDialogU8_With() instead.
+ */
+NFD_API nfdresult_t NFD_OpenDialogU8_With_Impl(nfdversion_t version,
+                                               nfdu8char_t** outPath,
+                                               const nfdopendialogu8args_t* args);
+
+/** Single file open dialog, with additional parameters.
+ *
+ *  It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function
+ *  returns NFD_OKAY.  See documentation of nfdopendialogu8args_t for details. */
+NFD_INLINE nfdresult_t NFD_OpenDialogU8_With(nfdu8char_t** outPath,
+                                             const nfdopendialogu8args_t* args) {
+    return NFD_OpenDialogU8_With_Impl(NFD_INTERFACE_VERSION, outPath, args);
+}
+
 /** Multiple file open dialog
  *
  *  It is the caller's responsibility to free `outPaths` via NFD_PathSet_FreeN() if this function
@@ -157,6 +242,36 @@ NFD_API nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
                                              const nfdu8filteritem_t* filterList,
                                              nfdfiltersize_t filterCount,
                                              const nfdu8char_t* defaultPath);
+
+/** This function is a library implementation detail.  Please use NFD_OpenDialogMultipleN_With()
+ * instead. */
+NFD_API nfdresult_t NFD_OpenDialogMultipleN_With_Impl(nfdversion_t version,
+                                                      const nfdpathset_t** outPaths,
+                                                      const nfdopendialognargs_t* args);
+
+/** Multiple file open dialog, with additional parameters.
+ *
+ *  It is the caller's responsibility to free `outPaths` via NFD_PathSet_FreeN() if this function
+ *  returns NFD_OKAY.  See documentation of nfdopendialognargs_t for details. */
+NFD_INLINE nfdresult_t NFD_OpenDialogMultipleN_With(const nfdpathset_t** outPaths,
+                                                    const nfdopendialognargs_t* args) {
+    return NFD_OpenDialogMultipleN_With_Impl(NFD_INTERFACE_VERSION, outPaths, args);
+}
+
+/** This function is a library implementation detail.  Please use NFD_OpenDialogU8_With() instead.
+ */
+NFD_API nfdresult_t NFD_OpenDialogMultipleU8_With_Impl(nfdversion_t version,
+                                                       const nfdpathset_t** outPaths,
+                                                       const nfdopendialogu8args_t* args);
+
+/** Multiple file open dialog, with additional parameters.
+ *
+ *  It is the caller's responsibility to free `outPaths` via NFD_PathSet_FreeU8() if this function
+ *  returns NFD_OKAY.  See documentation of nfdopendialogu8args_t for details. */
+NFD_INLINE nfdresult_t NFD_OpenDialogMultipleU8_With(const nfdpathset_t** outPaths,
+                                                     const nfdopendialogu8args_t* args) {
+    return NFD_OpenDialogMultipleU8_With_Impl(NFD_INTERFACE_VERSION, outPaths, args);
+}
 
 /** Save dialog
  *
@@ -184,7 +299,36 @@ NFD_API nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
                                      const nfdu8char_t* defaultPath,
                                      const nfdu8char_t* defaultName);
 
-/** Select folder dialog
+/** This function is a library implementation detail.  Please use NFD_SaveDialogN_With() instead. */
+NFD_API nfdresult_t NFD_SaveDialogN_With_Impl(nfdversion_t version,
+                                              nfdnchar_t** outPath,
+                                              const nfdsavedialognargs_t* args);
+
+/** Single file save dialog, with additional parameters.
+ *
+ *  It is the caller's responsibility to free `outPath` via NFD_FreePathN() if this function
+ *  returns NFD_OKAY.  See documentation of nfdsavedialognargs_t for details. */
+NFD_INLINE nfdresult_t NFD_SaveDialogN_With(nfdnchar_t** outPath,
+                                            const nfdsavedialognargs_t* args) {
+    return NFD_SaveDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, args);
+}
+
+/** This function is a library implementation detail.  Please use NFD_SaveDialogU8_With() instead.
+ */
+NFD_API nfdresult_t NFD_SaveDialogU8_With_Impl(nfdversion_t version,
+                                               nfdu8char_t** outPath,
+                                               const nfdsavedialogu8args_t* args);
+
+/** Single file save dialog, with additional parameters.
+ *
+ *  It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function
+ *  returns NFD_OKAY.  See documentation of nfdsavedialogu8args_t for details. */
+NFD_INLINE nfdresult_t NFD_SaveDialogU8_With(nfdu8char_t** outPath,
+                                             const nfdsavedialogu8args_t* args) {
+    return NFD_SaveDialogU8_With_Impl(NFD_INTERFACE_VERSION, outPath, args);
+}
+
+/** Select single folder dialog
  *
  *  It is the caller's responsibility to free `outPath` via NFD_FreePathN() if this function returns
  *  NFD_OKAY.
@@ -192,13 +336,42 @@ NFD_API nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
  *  @param defaultPath If null, the operating system will decide. */
 NFD_API nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath);
 
-/** Select folder dialog
+/** Select single folder dialog
  *
  *  It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function
  *  returns NFD_OKAY.
  *  @param[out] outPath
  *  @param defaultPath If null, the operating system will decide. */
 NFD_API nfdresult_t NFD_PickFolderU8(nfdu8char_t** outPath, const nfdu8char_t* defaultPath);
+
+/** This function is a library implementation detail.  Please use NFD_PickFolderN_With() instead. */
+NFD_API nfdresult_t NFD_PickFolderN_With_Impl(nfdversion_t version,
+                                              nfdnchar_t** outPath,
+                                              const nfdpickfoldernargs_t* args);
+
+/** Select single folder dialog, with additional parameters.
+ *
+ *  It is the caller's responsibility to free `outPath` via NFD_FreePathN() if this function
+ *  returns NFD_OKAY.  See documentation of nfdpickfoldernargs_t for details. */
+NFD_INLINE nfdresult_t NFD_PickFolderN_With(nfdnchar_t** outPath,
+                                            const nfdpickfoldernargs_t* args) {
+    return NFD_PickFolderN_With_Impl(NFD_INTERFACE_VERSION, outPath, args);
+}
+
+/** This function is a library implementation detail.  Please use NFD_PickFolderU8_With() instead.
+ */
+NFD_API nfdresult_t NFD_PickFolderU8_With_Impl(nfdversion_t version,
+                                               nfdu8char_t** outPath,
+                                               const nfdpickfolderu8args_t* args);
+
+/** Select single folder dialog, with additional parameters.
+ *
+ *  It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function
+ *  returns NFD_OKAY.  See documentation of nfdpickfolderu8args_t for details. */
+NFD_INLINE nfdresult_t NFD_PickFolderU8_With(nfdu8char_t** outPath,
+                                             const nfdpickfolderu8args_t* args) {
+    return NFD_PickFolderU8_With_Impl(NFD_INTERFACE_VERSION, outPath, args);
+}
 
 /** Get the last error
  *
@@ -308,6 +481,7 @@ typedef nfdu8filteritem_t nfdfilteritem_t;
 #define NFD_PathSet_EnumNext NFD_PathSet_EnumNextU8
 #endif  // NFD_NATIVE
 
+#undef NFD_INLINE
 #ifdef __cplusplus
 }
 #endif  // __cplusplus

--- a/src/include/nfd.hpp
+++ b/src/include/nfd.hpp
@@ -38,14 +38,16 @@ inline nfdresult_t OpenDialog(nfdnchar_t*& outPath,
                               const nfdnfilteritem_t* filterList = nullptr,
                               nfdfiltersize_t filterCount = 0,
                               const nfdnchar_t* defaultPath = nullptr) noexcept {
-    return ::NFD_OpenDialogN(&outPath, filterList, filterCount, defaultPath);
+    const nfdopendialognargs_t args{filterList, filterCount, defaultPath};
+    return ::NFD_OpenDialogN_With(&outPath, &args);
 }
 
 inline nfdresult_t OpenDialogMultiple(const nfdpathset_t*& outPaths,
                                       const nfdnfilteritem_t* filterList = nullptr,
                                       nfdfiltersize_t filterCount = 0,
                                       const nfdnchar_t* defaultPath = nullptr) noexcept {
-    return ::NFD_OpenDialogMultipleN(&outPaths, filterList, filterCount, defaultPath);
+    const nfdopendialognargs_t args{filterList, filterCount, defaultPath};
+    return ::NFD_OpenDialogMultipleN_With(&outPaths, &args);
 }
 
 inline nfdresult_t SaveDialog(nfdnchar_t*& outPath,
@@ -53,12 +55,14 @@ inline nfdresult_t SaveDialog(nfdnchar_t*& outPath,
                               nfdfiltersize_t filterCount = 0,
                               const nfdnchar_t* defaultPath = nullptr,
                               const nfdnchar_t* defaultName = nullptr) noexcept {
-    return ::NFD_SaveDialogN(&outPath, filterList, filterCount, defaultPath, defaultName);
+    const nfdsavedialognargs_t args{filterList, filterCount, defaultPath, defaultName};
+    return ::NFD_SaveDialogN_With(&outPath, &args);
 }
 
 inline nfdresult_t PickFolder(nfdnchar_t*& outPath,
                               const nfdnchar_t* defaultPath = nullptr) noexcept {
-    return ::NFD_PickFolderN(&outPath, defaultPath);
+    const nfdpickfoldernargs_t args{defaultPath};
+    return ::NFD_PickFolderN_With(&outPath, &args);
 }
 
 inline const char* GetError() noexcept {
@@ -99,29 +103,33 @@ inline void FreePath(nfdu8char_t* outPath) noexcept {
 
 inline nfdresult_t OpenDialog(nfdu8char_t*& outPath,
                               const nfdu8filteritem_t* filterList = nullptr,
-                              nfdfiltersize_t count = 0,
+                              nfdfiltersize_t filterCount = 0,
                               const nfdu8char_t* defaultPath = nullptr) noexcept {
-    return ::NFD_OpenDialogU8(&outPath, filterList, count, defaultPath);
+    const nfdopendialogu8args_t args{filterList, filterCount, defaultPath};
+    return ::NFD_OpenDialogU8_With(&outPath, &args);
 }
 
 inline nfdresult_t OpenDialogMultiple(const nfdpathset_t*& outPaths,
                                       const nfdu8filteritem_t* filterList = nullptr,
-                                      nfdfiltersize_t count = 0,
+                                      nfdfiltersize_t filterCount = 0,
                                       const nfdu8char_t* defaultPath = nullptr) noexcept {
-    return ::NFD_OpenDialogMultipleU8(&outPaths, filterList, count, defaultPath);
+    const nfdopendialogu8args_t args{filterList, filterCount, defaultPath};
+    return ::NFD_OpenDialogMultipleU8_With(&outPaths, &args);
 }
 
 inline nfdresult_t SaveDialog(nfdu8char_t*& outPath,
                               const nfdu8filteritem_t* filterList = nullptr,
-                              nfdfiltersize_t count = 0,
+                              nfdfiltersize_t filterCount = 0,
                               const nfdu8char_t* defaultPath = nullptr,
                               const nfdu8char_t* defaultName = nullptr) noexcept {
-    return ::NFD_SaveDialogU8(&outPath, filterList, count, defaultPath, defaultName);
+    const nfdsavedialogu8args_t args{filterList, filterCount, defaultPath, defaultName};
+    return ::NFD_SaveDialogU8_With(&outPath, &args);
 }
 
 inline nfdresult_t PickFolder(nfdu8char_t*& outPath,
                               const nfdu8char_t* defaultPath = nullptr) noexcept {
-    return ::NFD_PickFolderU8(&outPath, defaultPath);
+    const nfdpickfolderu8args_t args{defaultPath};
+    return ::NFD_PickFolderU8_With(&outPath, &args);
 }
 
 namespace PathSet {

--- a/src/nfd_cocoa.m
+++ b/src/nfd_cocoa.m
@@ -215,6 +215,19 @@ nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
                             const nfdnfilteritem_t* filterList,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath) {
+    nfdopendialognargs_t args = {0};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_OpenDialogN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdopendialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     nfdresult_t result = NFD_CANCEL;
     @autoreleasepool {
         NSWindow* keyWindow = [[NSApplication sharedApplication] keyWindow];
@@ -223,10 +236,10 @@ nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
         [dialog setAllowsMultipleSelection:NO];
 
         // Build the filter list
-        AddFilterListToDialog(dialog, filterList, filterCount);
+        AddFilterListToDialog(dialog, args->filterList, args->filterCount);
 
         // Set the starting directory
-        SetDefaultPath(dialog, defaultPath);
+        SetDefaultPath(dialog, args->defaultPath);
 
         if ([dialog runModal] == NSModalResponseOK) {
             const NSURL* url = [dialog URL];
@@ -247,10 +260,29 @@ nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
     return NFD_OpenDialogN(outPath, filterList, filterCount, defaultPath);
 }
 
+nfdresult_t NFD_OpenDialogU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdopendialogu8args_t* args) {
+    return NFD_OpenDialogN_With_Impl(version, outPath, args);
+}
+
 nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
                                     const nfdnfilteritem_t* filterList,
                                     nfdfiltersize_t filterCount,
                                     const nfdnchar_t* defaultPath) {
+    nfdopendialognargs_t args = {0};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogMultipleN_With_Impl(NFD_INTERFACE_VERSION, outPaths, &args);
+}
+
+nfdresult_t NFD_OpenDialogMultipleN_With_Impl(nfdversion_t version,
+                                              const nfdpathset_t** outPaths,
+                                              const nfdopendialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     nfdresult_t result = NFD_CANCEL;
     @autoreleasepool {
         NSWindow* keyWindow = [[NSApplication sharedApplication] keyWindow];
@@ -259,10 +291,10 @@ nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
         [dialog setAllowsMultipleSelection:YES];
 
         // Build the filter list
-        AddFilterListToDialog(dialog, filterList, filterCount);
+        AddFilterListToDialog(dialog, args->filterList, args->filterCount);
 
         // Set the starting directory
-        SetDefaultPath(dialog, defaultPath);
+        SetDefaultPath(dialog, args->defaultPath);
 
         if ([dialog runModal] == NSModalResponseOK) {
             const NSArray* urls = [dialog URLs];
@@ -288,11 +320,31 @@ nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
     return NFD_OpenDialogMultipleN(outPaths, filterList, filterCount, defaultPath);
 }
 
+nfdresult_t NFD_OpenDialogMultipleU8_With_Impl(nfdversion_t version,
+                                               const nfdpathset_t** outPaths,
+                                               const nfdopendialogu8args_t* args) {
+    return NFD_OpenDialogMultipleN_With_Impl(version, outPaths, args);
+}
+
 nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
                             const nfdnfilteritem_t* filterList,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath,
                             const nfdnchar_t* defaultName) {
+    nfdsavedialognargs_t args = {0};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    args.defaultName = defaultName;
+    return NFD_SaveDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_SaveDialogN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdsavedialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     nfdresult_t result = NFD_CANCEL;
     @autoreleasepool {
         NSWindow* keyWindow = [[NSApplication sharedApplication] keyWindow];
@@ -304,13 +356,13 @@ nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
         [dialog setAllowsOtherFileTypes:TRUE];
 
         // Build the filter list
-        AddFilterListToDialog(dialog, filterList, filterCount);
+        AddFilterListToDialog(dialog, args->filterList, args->filterCount);
 
         // Set the starting directory
-        SetDefaultPath(dialog, defaultPath);
+        SetDefaultPath(dialog, args->defaultPath);
 
         // Set the default file name
-        SetDefaultName(dialog, defaultName);
+        SetDefaultName(dialog, args->defaultName);
 
         if ([dialog runModal] == NSModalResponseOK) {
             const NSURL* url = [dialog URL];
@@ -332,7 +384,24 @@ nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
     return NFD_SaveDialogN(outPath, filterList, filterCount, defaultPath, defaultName);
 }
 
+nfdresult_t NFD_SaveDialogU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdsavedialogu8args_t* args) {
+    return NFD_SaveDialogN_With_Impl(version, outPath, args);
+}
+
 nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath) {
+    nfdpickfoldernargs_t args = {0};
+    args.defaultPath = defaultPath;
+    return NFD_PickFolderN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_PickFolderN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdpickfoldernargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     nfdresult_t result = NFD_CANCEL;
     @autoreleasepool {
         NSWindow* keyWindow = [[NSApplication sharedApplication] keyWindow];
@@ -344,7 +413,7 @@ nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath)
         [dialog setCanChooseFiles:NO];
 
         // Set the starting directory
-        SetDefaultPath(dialog, defaultPath);
+        SetDefaultPath(dialog, args->defaultPath);
 
         if ([dialog runModal] == NSModalResponseOK) {
             const NSURL* url = [dialog URL];
@@ -360,6 +429,12 @@ nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath)
 
 nfdresult_t NFD_PickFolderU8(nfdu8char_t** outPath, const nfdu8char_t* defaultPath) {
     return NFD_PickFolderN(outPath, defaultPath);
+}
+
+nfdresult_t NFD_PickFolderU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdpickfolderu8args_t* args) {
+    return NFD_PickFolderN_With_Impl(version, outPath, args);
 }
 
 nfdresult_t NFD_PathSet_GetCount(const nfdpathset_t* pathSet, nfdpathsetsize_t* count) {

--- a/src/nfd_gtk.cpp
+++ b/src/nfd_gtk.cpp
@@ -416,6 +416,19 @@ nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
                             const nfdnfilteritem_t* filterList,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath) {
+    nfdopendialognargs_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_OpenDialogN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdopendialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     GtkWidget* widget = gtk_file_chooser_dialog_new("Open File",
                                                     nullptr,
                                                     GTK_FILE_CHOOSER_ACTION_OPEN,
@@ -429,10 +442,10 @@ nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
     Widget_Guard widgetGuard(widget);
 
     /* Build the filter list */
-    AddFiltersToDialog(GTK_FILE_CHOOSER(widget), filterList, filterCount);
+    AddFiltersToDialog(GTK_FILE_CHOOSER(widget), args->filterList, args->filterCount);
 
     /* Set the default path */
-    SetDefaultPath(GTK_FILE_CHOOSER(widget), defaultPath);
+    SetDefaultPath(GTK_FILE_CHOOSER(widget), args->defaultPath);
 
     if (RunDialogWithFocus(GTK_DIALOG(widget)) == GTK_RESPONSE_ACCEPT) {
         // write out the file name
@@ -450,10 +463,28 @@ nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
                              const nfdu8char_t* defaultPath)
     __attribute__((alias("NFD_OpenDialogN")));
 
+nfdresult_t NFD_OpenDialogU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdopendialogu8args_t* args)
+    __attribute__((alias("NFD_OpenDialogN_With_Impl")));
+
 nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
                                     const nfdnfilteritem_t* filterList,
                                     nfdfiltersize_t filterCount,
                                     const nfdnchar_t* defaultPath) {
+    nfdopendialognargs_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogMultipleN_With_Impl(NFD_INTERFACE_VERSION, outPaths, &args);
+}
+
+nfdresult_t NFD_OpenDialogMultipleN_With_Impl(nfdversion_t version,
+                                              const nfdpathset_t** outPaths,
+                                              const nfdopendialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     GtkWidget* widget = gtk_file_chooser_dialog_new("Open Files",
                                                     nullptr,
                                                     GTK_FILE_CHOOSER_ACTION_OPEN,
@@ -470,10 +501,10 @@ nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
     gtk_file_chooser_set_select_multiple(GTK_FILE_CHOOSER(widget), TRUE);
 
     /* Build the filter list */
-    AddFiltersToDialog(GTK_FILE_CHOOSER(widget), filterList, filterCount);
+    AddFiltersToDialog(GTK_FILE_CHOOSER(widget), args->filterList, args->filterCount);
 
     /* Set the default path */
-    SetDefaultPath(GTK_FILE_CHOOSER(widget), defaultPath);
+    SetDefaultPath(GTK_FILE_CHOOSER(widget), args->defaultPath);
 
     if (RunDialogWithFocus(GTK_DIALOG(widget)) == GTK_RESPONSE_ACCEPT) {
         // write out the file name
@@ -492,11 +523,30 @@ nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
                                      const nfdu8char_t* defaultPath)
     __attribute__((alias("NFD_OpenDialogMultipleN")));
 
+nfdresult_t NFD_OpenDialogMultipleU8_With_Impl(nfdversion_t version,
+                                               const nfdpathset_t** outPaths,
+                                               const nfdopendialogu8args_t* args)
+    __attribute__((alias("NFD_OpenDialogMultipleN_With_Impl")));
+
 nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
                             const nfdnfilteritem_t* filterList,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath,
                             const nfdnchar_t* defaultName) {
+    nfdsavedialognargs_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    args.defaultName = defaultName;
+    return NFD_SaveDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_SaveDialogN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdsavedialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     GtkWidget* widget = gtk_file_chooser_dialog_new("Save File",
                                                     nullptr,
                                                     GTK_FILE_CHOOSER_ACTION_SAVE,
@@ -516,13 +566,13 @@ nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
     ButtonClickedArgs buttonClickedArgs;
     buttonClickedArgs.chooser = GTK_FILE_CHOOSER(widget);
     buttonClickedArgs.map =
-        AddFiltersToDialogWithMap(GTK_FILE_CHOOSER(widget), filterList, filterCount);
+        AddFiltersToDialogWithMap(GTK_FILE_CHOOSER(widget), args->filterList, args->filterCount);
 
     /* Set the default path */
-    SetDefaultPath(GTK_FILE_CHOOSER(widget), defaultPath);
+    SetDefaultPath(GTK_FILE_CHOOSER(widget), args->defaultPath);
 
     /* Set the default file name */
-    SetDefaultName(GTK_FILE_CHOOSER(widget), defaultName);
+    SetDefaultName(GTK_FILE_CHOOSER(widget), args->defaultName);
 
     /* set the handler to add file extension */
     gulong handlerID = g_signal_connect(G_OBJECT(saveButton),
@@ -555,7 +605,23 @@ nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
                              const nfdu8char_t* defaultName)
     __attribute__((alias("NFD_SaveDialogN")));
 
+nfdresult_t NFD_SaveDialogU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdsavedialogu8args_t* args)
+    __attribute__((alias("NFD_SaveDialogN_With_Impl")));
+
 nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath) {
+    nfdpickfoldernargs_t args{};
+    args.defaultPath = defaultPath;
+    return NFD_PickFolderN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_PickFolderN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdpickfoldernargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     GtkWidget* widget = gtk_file_chooser_dialog_new("Select folder",
                                                     nullptr,
                                                     GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
@@ -569,7 +635,7 @@ nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath)
     Widget_Guard widgetGuard(widget);
 
     /* Set the default path */
-    SetDefaultPath(GTK_FILE_CHOOSER(widget), defaultPath);
+    SetDefaultPath(GTK_FILE_CHOOSER(widget), args->defaultPath);
 
     if (RunDialogWithFocus(GTK_DIALOG(widget)) == GTK_RESPONSE_ACCEPT) {
         // write out the file name
@@ -583,6 +649,11 @@ nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath)
 
 nfdresult_t NFD_PickFolderU8(nfdu8char_t** outPath, const nfdu8char_t* defaultPath)
     __attribute__((alias("NFD_PickFolderN")));
+
+nfdresult_t NFD_PickFolderU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdpickfolderu8args_t* args)
+    __attribute__((alias("NFD_PickFolderN_With_Impl")));
 
 nfdresult_t NFD_PathSet_GetCount(const nfdpathset_t* pathSet, nfdpathsetsize_t* count) {
     assert(pathSet);

--- a/src/nfd_portal.cpp
+++ b/src/nfd_portal.cpp
@@ -1377,10 +1377,23 @@ nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
                             const nfdnfilteritem_t* filterList,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath) {
+    nfdopendialognargs_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_OpenDialogN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdopendialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     DBusMessage* msg;
     {
-        const nfdresult_t res =
-            NFD_DBus_OpenFile<false, false>(msg, filterList, filterCount, defaultPath);
+        const nfdresult_t res = NFD_DBus_OpenFile<false, false>(
+            msg, args->filterList, args->filterCount, args->defaultPath);
         if (res != NFD_OKAY) {
             return res;
         }
@@ -1404,14 +1417,32 @@ nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
                              const nfdu8char_t* defaultPath)
     __attribute__((alias("NFD_OpenDialogN")));
 
+nfdresult_t NFD_OpenDialogU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdopendialogu8args_t* args)
+    __attribute__((alias("NFD_OpenDialogN_With_Impl")));
+
 nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
                                     const nfdnfilteritem_t* filterList,
                                     nfdfiltersize_t filterCount,
                                     const nfdnchar_t* defaultPath) {
+    nfdopendialognargs_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogMultipleN_With_Impl(NFD_INTERFACE_VERSION, outPaths, &args);
+}
+
+nfdresult_t NFD_OpenDialogMultipleN_With_Impl(nfdversion_t version,
+                                              const nfdpathset_t** outPaths,
+                                              const nfdopendialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     DBusMessage* msg;
     {
-        const nfdresult_t res =
-            NFD_DBus_OpenFile<true, false>(msg, filterList, filterCount, defaultPath);
+        const nfdresult_t res = NFD_DBus_OpenFile<true, false>(
+            msg, args->filterList, args->filterCount, args->defaultPath);
         if (res != NFD_OKAY) {
             return res;
         }
@@ -1434,15 +1465,34 @@ nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
                                      const nfdu8char_t* defaultPath)
     __attribute__((alias("NFD_OpenDialogMultipleN")));
 
+nfdresult_t NFD_OpenDialogMultipleU8_With_Impl(nfdversion_t version,
+                                               const nfdpathset_t** outPaths,
+                                               const nfdopendialogu8args_t* args)
+    __attribute__((alias("NFD_OpenDialogMultipleN_With_Impl")));
+
 nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
                             const nfdnfilteritem_t* filterList,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath,
                             const nfdnchar_t* defaultName) {
+    nfdsavedialognargs_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    args.defaultName = defaultName;
+    return NFD_SaveDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_SaveDialogN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdsavedialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     DBusMessage* msg;
     {
-        const nfdresult_t res =
-            NFD_DBus_SaveFile(msg, filterList, filterCount, defaultPath, defaultName);
+        const nfdresult_t res = NFD_DBus_SaveFile(
+            msg, args->filterList, args->filterCount, args->defaultPath, args->defaultName);
         if (res != NFD_OKAY) {
             return res;
         }
@@ -1480,8 +1530,24 @@ nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
                              const nfdu8char_t* defaultName)
     __attribute__((alias("NFD_SaveDialogN")));
 
+nfdresult_t NFD_SaveDialogU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdsavedialogu8args_t* args)
+    __attribute__((alias("NFD_SaveDialogN_With_Impl")));
+
 nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath) {
-    (void)defaultPath;  // Default path not supported for portal backend
+    nfdpickfoldernargs_t args{};
+    args.defaultPath = defaultPath;
+    return NFD_PickFolderN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_PickFolderN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdpickfoldernargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
+    (void)args;  // Default path not supported for portal backend
 
     {
         dbus_uint32_t version;
@@ -1501,7 +1567,7 @@ nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath)
 
     DBusMessage* msg;
     {
-        const nfdresult_t res = NFD_DBus_OpenFile<false, true>(msg, nullptr, 0, defaultPath);
+        const nfdresult_t res = NFD_DBus_OpenFile<false, true>(msg, nullptr, 0, args->defaultPath);
         if (res != NFD_OKAY) {
             return res;
         }
@@ -1521,6 +1587,11 @@ nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath)
 
 nfdresult_t NFD_PickFolderU8(nfdu8char_t** outPath, const nfdu8char_t* defaultPath)
     __attribute__((alias("NFD_PickFolderN")));
+
+nfdresult_t NFD_PickFolderU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdpickfolderu8args_t* args)
+    __attribute__((alias("NFD_PickFolderN_With_Impl")));
 
 nfdresult_t NFD_PathSet_GetCount(const nfdpathset_t* pathSet, nfdpathsetsize_t* count) {
     assert(pathSet);

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -334,6 +334,19 @@ nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
                             const nfdnfilteritem_t* filterList,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath) {
+    nfdopendialognargs_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_OpenDialogN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdopendialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     ::IFileOpenDialog* fileOpenDialog;
 
     // Create dialog
@@ -352,17 +365,17 @@ nfdresult_t NFD_OpenDialogN(nfdnchar_t** outPath,
     Release_Guard<::IFileOpenDialog> fileOpenDialogGuard(fileOpenDialog);
 
     // Build the filter list
-    if (!AddFiltersToDialog(fileOpenDialog, filterList, filterCount)) {
+    if (!AddFiltersToDialog(fileOpenDialog, args->filterList, args->filterCount)) {
         return NFD_ERROR;
     }
 
     // Set auto-completed default extension
-    if (!SetDefaultExtension(fileOpenDialog, filterList, filterCount)) {
+    if (!SetDefaultExtension(fileOpenDialog, args->filterList, args->filterCount)) {
         return NFD_ERROR;
     }
 
     // Set the default path
-    if (!SetDefaultPath(fileOpenDialog, defaultPath)) {
+    if (!SetDefaultPath(fileOpenDialog, args->defaultPath)) {
         return NFD_ERROR;
     }
 
@@ -405,7 +418,20 @@ nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
                                     const nfdnfilteritem_t* filterList,
                                     nfdfiltersize_t filterCount,
                                     const nfdnchar_t* defaultPath) {
-    ::IFileOpenDialog* fileOpenDialog(nullptr);
+    nfdopendialognargs_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogMultipleN_With_Impl(NFD_INTERFACE_VERSION, outPaths, &args);
+}
+
+nfdresult_t NFD_OpenDialogMultipleN_With_Impl(nfdversion_t version,
+                                              const nfdpathset_t** outPaths,
+                                              const nfdopendialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
+    ::IFileOpenDialog* fileOpenDialog;
 
     // Create dialog
     HRESULT result = ::CoCreateInstance(::CLSID_FileOpenDialog,
@@ -423,17 +449,17 @@ nfdresult_t NFD_OpenDialogMultipleN(const nfdpathset_t** outPaths,
     Release_Guard<::IFileOpenDialog> fileOpenDialogGuard(fileOpenDialog);
 
     // Build the filter list
-    if (!AddFiltersToDialog(fileOpenDialog, filterList, filterCount)) {
+    if (!AddFiltersToDialog(fileOpenDialog, args->filterList, args->filterCount)) {
         return NFD_ERROR;
     }
 
     // Set auto-completed default extension
-    if (!SetDefaultExtension(fileOpenDialog, filterList, filterCount)) {
+    if (!SetDefaultExtension(fileOpenDialog, args->filterList, args->filterCount)) {
         return NFD_ERROR;
     }
 
     // Set the default path
-    if (!SetDefaultPath(fileOpenDialog, defaultPath)) {
+    if (!SetDefaultPath(fileOpenDialog, args->defaultPath)) {
         return NFD_ERROR;
     }
 
@@ -469,6 +495,20 @@ nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
                             nfdfiltersize_t filterCount,
                             const nfdnchar_t* defaultPath,
                             const nfdnchar_t* defaultName) {
+    nfdsavedialognargs_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    args.defaultName = defaultName;
+    return NFD_SaveDialogN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_SaveDialogN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdsavedialognargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     ::IFileSaveDialog* fileSaveDialog;
 
     // Create dialog
@@ -487,22 +527,22 @@ nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
     Release_Guard<::IFileSaveDialog> fileSaveDialogGuard(fileSaveDialog);
 
     // Build the filter list
-    if (!AddFiltersToDialog(fileSaveDialog, filterList, filterCount)) {
+    if (!AddFiltersToDialog(fileSaveDialog, args->filterList, args->filterCount)) {
         return NFD_ERROR;
     }
 
     // Set default extension
-    if (!SetDefaultExtension(fileSaveDialog, filterList, filterCount)) {
+    if (!SetDefaultExtension(fileSaveDialog, args->filterList, args->filterCount)) {
         return NFD_ERROR;
     }
 
     // Set the default path
-    if (!SetDefaultPath(fileSaveDialog, defaultPath)) {
+    if (!SetDefaultPath(fileSaveDialog, args->defaultPath)) {
         return NFD_ERROR;
     }
 
     // Set the default name
-    if (!SetDefaultName(fileSaveDialog, defaultName)) {
+    if (!SetDefaultName(fileSaveDialog, args->defaultName)) {
         return NFD_ERROR;
     }
 
@@ -542,6 +582,17 @@ nfdresult_t NFD_SaveDialogN(nfdnchar_t** outPath,
 }
 
 nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath) {
+    nfdpickfoldernargs_t args{};
+    args.defaultPath = defaultPath;
+    return NFD_PickFolderN_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_PickFolderN_With_Impl(nfdversion_t version,
+                                      nfdnchar_t** outPath,
+                                      const nfdpickfoldernargs_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     ::IFileOpenDialog* fileOpenDialog;
 
     // Create dialog
@@ -557,7 +608,7 @@ nfdresult_t NFD_PickFolderN(nfdnchar_t** outPath, const nfdnchar_t* defaultPath)
     Release_Guard<::IFileOpenDialog> fileOpenDialogGuard(fileOpenDialog);
 
     // Set the default path
-    if (!SetDefaultPath(fileOpenDialog, defaultPath)) {
+    if (!SetDefaultPath(fileOpenDialog, args->defaultPath)) {
         return NFD_ERROR;
     }
 
@@ -810,23 +861,37 @@ void NFD_FreePathU8(nfdu8char_t* outPath) {
 
 nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
                              const nfdu8filteritem_t* filterList,
-                             nfdfiltersize_t count,
+                             nfdfiltersize_t filterCount,
                              const nfdu8char_t* defaultPath) {
+    nfdopendialogu8args_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogU8_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_OpenDialogU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdopendialogu8args_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     // populate the real nfdnfilteritem_t
     FilterItem_Guard filterItemsNGuard;
-    if (!CopyFilterItem(filterList, count, filterItemsNGuard)) {
+    if (!CopyFilterItem(args->filterList, args->filterCount, filterItemsNGuard)) {
         return NFD_ERROR;
     }
 
     // convert and normalize the default path, but only if it is not nullptr
     FreeCheck_Guard<nfdnchar_t> defaultPathNGuard;
-    ConvertU8ToNative(defaultPath, defaultPathNGuard);
+    ConvertU8ToNative(args->defaultPath, defaultPathNGuard);
     NormalizePathSeparator(defaultPathNGuard.data);
 
     // call the native function
     nfdnchar_t* outPathN;
-    nfdresult_t res =
-        NFD_OpenDialogN(&outPathN, filterItemsNGuard.data, count, defaultPathNGuard.data);
+    const nfdopendialognargs_t argsN{
+        filterItemsNGuard.data, args->filterCount, defaultPathNGuard.data};
+    nfdresult_t res = NFD_OpenDialogN_With_Impl(NFD_INTERFACE_VERSION, &outPathN, &argsN);
 
     if (res != NFD_OKAY) {
         return res;
@@ -845,21 +910,36 @@ nfdresult_t NFD_OpenDialogU8(nfdu8char_t** outPath,
  * returns NFD_OKAY */
 nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
                                      const nfdu8filteritem_t* filterList,
-                                     nfdfiltersize_t count,
+                                     nfdfiltersize_t filterCount,
                                      const nfdu8char_t* defaultPath) {
+    nfdopendialogu8args_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    return NFD_OpenDialogMultipleU8_With_Impl(NFD_INTERFACE_VERSION, outPaths, &args);
+}
+
+nfdresult_t NFD_OpenDialogMultipleU8_With_Impl(nfdversion_t version,
+                                               const nfdpathset_t** outPaths,
+                                               const nfdopendialogu8args_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     // populate the real nfdnfilteritem_t
     FilterItem_Guard filterItemsNGuard;
-    if (!CopyFilterItem(filterList, count, filterItemsNGuard)) {
+    if (!CopyFilterItem(args->filterList, args->filterCount, filterItemsNGuard)) {
         return NFD_ERROR;
     }
 
     // convert and normalize the default path, but only if it is not nullptr
     FreeCheck_Guard<nfdnchar_t> defaultPathNGuard;
-    ConvertU8ToNative(defaultPath, defaultPathNGuard);
+    ConvertU8ToNative(args->defaultPath, defaultPathNGuard);
     NormalizePathSeparator(defaultPathNGuard.data);
 
     // call the native function
-    return NFD_OpenDialogMultipleN(outPaths, filterItemsNGuard.data, count, defaultPathNGuard.data);
+    const nfdopendialognargs_t argsN{
+        filterItemsNGuard.data, args->filterCount, defaultPathNGuard.data};
+    return NFD_OpenDialogMultipleN_With_Impl(NFD_INTERFACE_VERSION, outPaths, &argsN);
 }
 
 /* save dialog */
@@ -867,28 +947,43 @@ nfdresult_t NFD_OpenDialogMultipleU8(const nfdpathset_t** outPaths,
  * NFD_OKAY */
 nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
                              const nfdu8filteritem_t* filterList,
-                             nfdfiltersize_t count,
+                             nfdfiltersize_t filterCount,
                              const nfdu8char_t* defaultPath,
                              const nfdu8char_t* defaultName) {
+    nfdsavedialogu8args_t args{};
+    args.filterList = filterList;
+    args.filterCount = filterCount;
+    args.defaultPath = defaultPath;
+    args.defaultName = defaultName;
+    return NFD_SaveDialogU8_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_SaveDialogU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdsavedialogu8args_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     // populate the real nfdnfilteritem_t
     FilterItem_Guard filterItemsNGuard;
-    if (!CopyFilterItem(filterList, count, filterItemsNGuard)) {
+    if (!CopyFilterItem(args->filterList, args->filterCount, filterItemsNGuard)) {
         return NFD_ERROR;
     }
 
     // convert and normalize the default path, but only if it is not nullptr
     FreeCheck_Guard<nfdnchar_t> defaultPathNGuard;
-    ConvertU8ToNative(defaultPath, defaultPathNGuard);
+    ConvertU8ToNative(args->defaultPath, defaultPathNGuard);
     NormalizePathSeparator(defaultPathNGuard.data);
 
     // convert the default name, but only if it is not nullptr
     FreeCheck_Guard<nfdnchar_t> defaultNameNGuard;
-    ConvertU8ToNative(defaultName, defaultNameNGuard);
+    ConvertU8ToNative(args->defaultName, defaultNameNGuard);
 
     // call the native function
     nfdnchar_t* outPathN;
-    nfdresult_t res = NFD_SaveDialogN(
-        &outPathN, filterItemsNGuard.data, count, defaultPathNGuard.data, defaultNameNGuard.data);
+    const nfdsavedialognargs_t argsN{
+        filterItemsNGuard.data, args->filterCount, defaultPathNGuard.data, defaultNameNGuard.data};
+    nfdresult_t res = NFD_SaveDialogN_With_Impl(NFD_INTERFACE_VERSION, &outPathN, &argsN);
 
     if (res != NFD_OKAY) {
         return res;
@@ -906,14 +1001,26 @@ nfdresult_t NFD_SaveDialogU8(nfdu8char_t** outPath,
 /* It is the caller's responsibility to free `outPath` via NFD_FreePathU8() if this function returns
  * NFD_OKAY */
 nfdresult_t NFD_PickFolderU8(nfdu8char_t** outPath, const nfdu8char_t* defaultPath) {
+    nfdpickfolderu8args_t args{};
+    args.defaultPath = defaultPath;
+    return NFD_PickFolderU8_With_Impl(NFD_INTERFACE_VERSION, outPath, &args);
+}
+
+nfdresult_t NFD_PickFolderU8_With_Impl(nfdversion_t version,
+                                       nfdu8char_t** outPath,
+                                       const nfdpickfolderu8args_t* args) {
+    // We haven't needed to bump the interface version yet.
+    (void)version;
+
     // convert and normalize the default path, but only if it is not nullptr
     FreeCheck_Guard<nfdnchar_t> defaultPathNGuard;
-    ConvertU8ToNative(defaultPath, defaultPathNGuard);
+    ConvertU8ToNative(args->defaultPath, defaultPathNGuard);
     NormalizePathSeparator(defaultPathNGuard.data);
 
     // call the native function
     nfdnchar_t* outPathN;
-    nfdresult_t res = NFD_PickFolderN(&outPathN, defaultPathNGuard.data);
+    const nfdpickfoldernargs_t argsN{defaultPathNGuard.data};
+    nfdresult_t res = NFD_PickFolderN_With_Impl(NFD_INTERFACE_VERSION, &outPathN, &argsN);
 
     if (res != NFD_OKAY) {
         return res;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,8 @@ set(TEST_LIST
   test_opendialog.c
   test_opendialog_cpp.cpp
   test_opendialog_native.c
+  test_opendialog_with.c
+  test_opendialog_native_with.c
   test_opendialogmultiple.c
   test_opendialogmultiple_cpp.cpp
   test_opendialogmultiple_native.c
@@ -11,8 +13,12 @@ set(TEST_LIST
   test_pickfolder.c
   test_pickfolder_cpp.cpp
   test_pickfolder_native.c
+  test_pickfolder_with.c
+  test_pickfolder_native_with.c
   test_savedialog.c
-  test_savedialog_native.c)
+  test_savedialog_native.c
+  test_savedialog_with.c
+  test_savedialog_native_with.c)
   
 foreach (TEST ${TEST_LIST})
   string(REPLACE "." "_" CLEAN_TEST_NAME ${TEST})

--- a/test/test_opendialog_native_with.c
+++ b/test/test_opendialog_native_with.c
@@ -1,0 +1,52 @@
+#define NFD_NATIVE
+#include <nfd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* this test should compile on all supported platforms */
+
+int main(void) {
+    // initialize NFD
+    // either call NFD_Init at the start of your program and NFD_Quit at the end of your program,
+    // or before/after every time you want to show a file dialog.
+    NFD_Init();
+
+    nfdchar_t* outPath;
+
+    // prepare filters for the dialog
+#ifdef _WIN32
+    nfdfilteritem_t filterItem[2] = {{L"Source code", L"c,cpp,cc"}, {L"Headers", L"h,hpp"}};
+#else
+    nfdfilteritem_t filterItem[2] = {{"Source code", "c,cpp,cc"}, {"Headers", "h,hpp"}};
+#endif
+
+    // show the dialog
+    nfdopendialognargs_t args = {0};
+    args.filterList = filterItem;
+    args.filterCount = 2;
+    nfdresult_t result = NFD_OpenDialogN_With(&outPath, &args);
+    if (result == NFD_OKAY) {
+        puts("Success!");
+#ifdef _WIN32
+#ifdef _MSC_VER
+        _putws(outPath);
+#else
+        fputws(outPath, stdin);
+#endif
+#else
+        puts(outPath);
+#endif
+        // remember to free the memory (since NFD_OKAY is returned)
+        NFD_FreePath(outPath);
+    } else if (result == NFD_CANCEL) {
+        puts("User pressed cancel.");
+    } else {
+        printf("Error: %s\n", NFD_GetError());
+    }
+
+    // Quit NFD
+    NFD_Quit();
+
+    return 0;
+}

--- a/test/test_opendialog_with.c
+++ b/test/test_opendialog_with.c
@@ -1,0 +1,39 @@
+#include <nfd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* this test should compile on all supported platforms */
+
+int main(void) {
+    // initialize NFD
+    // either call NFD_Init at the start of your program and NFD_Quit at the end of your program,
+    // or before/after every time you want to show a file dialog.
+    NFD_Init();
+
+    nfdchar_t* outPath;
+
+    // prepare filters for the dialog
+    nfdfilteritem_t filterItem[2] = {{"Source code", "c,cpp,cc"}, {"Headers", "h,hpp"}};
+
+    // show the dialog
+    nfdopendialogu8args_t args = {0};
+    args.filterList = filterItem;
+    args.filterCount = 2;
+    nfdresult_t result = NFD_OpenDialogU8_With(&outPath, &args);
+    if (result == NFD_OKAY) {
+        puts("Success!");
+        puts(outPath);
+        // remember to free the memory (since NFD_OKAY is returned)
+        NFD_FreePath(outPath);
+    } else if (result == NFD_CANCEL) {
+        puts("User pressed cancel.");
+    } else {
+        printf("Error: %s\n", NFD_GetError());
+    }
+
+    // Quit NFD
+    NFD_Quit();
+
+    return 0;
+}

--- a/test/test_pickfolder_native_with.c
+++ b/test/test_pickfolder_native_with.c
@@ -1,0 +1,43 @@
+#define NFD_NATIVE
+#include <nfd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* this test should compile on all supported platforms */
+
+int main(void) {
+    // initialize NFD
+    // either call NFD_Init at the start of your program and NFD_Quit at the end of your program,
+    // or before/after every time you want to show a file dialog.
+    NFD_Init();
+
+    nfdchar_t* outPath;
+
+    // show the dialog
+    nfdpickfoldernargs_t args = {0};
+    nfdresult_t result = NFD_PickFolderN_With(&outPath, &args);
+    if (result == NFD_OKAY) {
+        puts("Success!");
+#ifdef _WIN32
+#ifdef _MSC_VER
+        _putws(outPath);
+#else
+        fputws(outPath, stdin);
+#endif
+#else
+        puts(outPath);
+#endif
+        // remember to free the memory (since NFD_OKAY is returned)
+        NFD_FreePath(outPath);
+    } else if (result == NFD_CANCEL) {
+        puts("User pressed cancel.");
+    } else {
+        printf("Error: %s\n", NFD_GetError());
+    }
+
+    // Quit NFD
+    NFD_Quit();
+
+    return 0;
+}

--- a/test/test_pickfolder_with.c
+++ b/test/test_pickfolder_with.c
@@ -1,0 +1,34 @@
+#include <nfd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* this test should compile on all supported platforms */
+
+int main(void) {
+    // initialize NFD
+    // either call NFD_Init at the start of your program and NFD_Quit at the end of your program,
+    // or before/after every time you want to show a file dialog.
+    NFD_Init();
+
+    nfdchar_t* outPath;
+
+    // show the dialog
+    nfdpickfolderu8args_t args = {0};
+    nfdresult_t result = NFD_PickFolderU8_With(&outPath, &args);
+    if (result == NFD_OKAY) {
+        puts("Success!");
+        puts(outPath);
+        // remember to free the memory (since NFD_OKAY is returned)
+        NFD_FreePath(outPath);
+    } else if (result == NFD_CANCEL) {
+        puts("User pressed cancel.");
+    } else {
+        printf("Error: %s\n", NFD_GetError());
+    }
+
+    // Quit NFD
+    NFD_Quit();
+
+    return 0;
+}

--- a/test/test_savedialog_native_with.c
+++ b/test/test_savedialog_native_with.c
@@ -1,0 +1,59 @@
+#define NFD_NATIVE
+#include <nfd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* this test should compile on all supported platforms */
+
+int main(void) {
+    // initialize NFD
+    // either call NFD_Init at the start of your program and NFD_Quit at the end of your program,
+    // or before/after every time you want to show a file dialog.
+    NFD_Init();
+
+    nfdchar_t* savePath;
+
+    // prepare filters for the dialog
+#ifdef _WIN32
+    nfdfilteritem_t filterItem[2] = {{L"Source code", L"c,cpp,cc"}, {L"Headers", L"h,hpp"}};
+#else
+    nfdfilteritem_t filterItem[2] = {{"Source code", "c,cpp,cc"}, {"Headers", "h,hpp"}};
+#endif
+
+#ifdef _WIN32
+    const wchar_t* defaultPath = L"Untitled.c";
+#else
+    const char* defaultPath = "Untitled.c";
+#endif
+
+    // show the dialog
+    nfdsavedialognargs_t args = {0};
+    args.filterList = filterItem;
+    args.filterCount = 2;
+    args.defaultName = defaultPath;
+    nfdresult_t result = NFD_SaveDialogN_With(&savePath, &args);
+    if (result == NFD_OKAY) {
+        puts("Success!");
+#ifdef _WIN32
+#ifdef _MSC_VER
+        _putws(savePath);
+#else
+        fputws(savePath, stdin);
+#endif
+#else
+        puts(savePath);
+#endif
+        // remember to free the memory (since NFD_OKAY is returned)
+        NFD_FreePath(savePath);
+    } else if (result == NFD_CANCEL) {
+        puts("User pressed cancel.");
+    } else {
+        printf("Error: %s\n", NFD_GetError());
+    }
+
+    // Quit NFD
+    NFD_Quit();
+
+    return 0;
+}

--- a/test/test_savedialog_with.c
+++ b/test/test_savedialog_with.c
@@ -1,0 +1,40 @@
+#include <nfd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* this test should compile on all supported platforms */
+
+int main(void) {
+    // initialize NFD
+    // either call NFD_Init at the start of your program and NFD_Quit at the end of your program,
+    // or before/after every time you want to show a file dialog.
+    NFD_Init();
+
+    nfdchar_t* savePath;
+
+    // prepare filters for the dialog
+    nfdfilteritem_t filterItem[2] = {{"Source code", "c,cpp,cc"}, {"Header", "h,hpp"}};
+
+    // show the dialog
+    nfdsavedialogu8args_t args = {0};
+    args.filterList = filterItem;
+    args.filterCount = 2;
+    args.defaultName = "Untitled.c";
+    nfdresult_t result = NFD_SaveDialogU8_With(&savePath, &args);
+    if (result == NFD_OKAY) {
+        puts("Success!");
+        puts(savePath);
+        // remember to free the memory (since NFD_OKAY is returned)
+        NFD_FreePath(savePath);
+    } else if (result == NFD_CANCEL) {
+        puts("User pressed cancel.");
+    } else {
+        printf("Error: %s\n", NFD_GetError());
+    }
+
+    // Quit NFD
+    NFD_Quit();
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds a new API function for each of the four kinds of dialogs, which take in a versioned struct.  The version is set by an inline function in nfd.h, and the library checks the version to determine the number of fields in the struct.  Additional fields can then be added to the end of the struct without breaking forward compatibility (binary built with an older version of NFDe works with a newer version of NFDe) or backward compatibility (automatically by ignoring the additional fields).

This will allow new options to be added without breaking forward compatibility, which will make #90, #93, #99, and #126 implementable.

Resolves #92.