### PR TITLE
New feature: Accept native parent window handle and implement glue code to major platform abstraction frameworks

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Installing Dependencies
+    - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get install dos2unix
     - name: Convert to Unix line endings
       run: dos2unix */*
@@ -72,7 +72,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Installing Dependencies
+    - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get install ${{ matrix.portal.dep }}
     - name: Configure
       run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${{ matrix.compiler.c }} -DCMAKE_CXX_COMPILER=${{ matrix.compiler.cpp }} -DCMAKE_CXX_STANDARD=${{ matrix.cppstd }} -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_PORTAL=${{ matrix.portal.flag }} -DNFD_APPEND_EXTENSION=${{ matrix.autoappend.flag }} -DBUILD_SHARED_LIBS=${{ matrix.shared_lib.flag }} -DNFD_BUILD_TESTS=ON ..
@@ -189,3 +189,75 @@ jobs:
         path: |
           build/src/*
           build/test/*
+
+  build-ubuntu-sdl2:
+
+    name: Ubuntu latest - GCC, ${{ matrix.portal.name }}, Static, SDL2
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        portal: [ {flag: OFF, dep: libgtk-3-dev, name: GTK}, {flag: ON, dep: libdbus-1-dev, name: Portal} ] # The NFD_PORTAL setting defaults to OFF (i.e. uses GTK)
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: sudo apt-get update && sudo apt-get install ${{ matrix.portal.dep }} libsdl2-dev libsdl2-ttf-dev
+    - name: Configure
+      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_PORTAL=${{ matrix.portal.flag }} -DNFD_APPEND_EXTENSION=OFF -DNFD_BUILD_TESTS=OFF -DNFD_BUILD_SDL2_TESTS=ON ..
+    - name: Build
+      run: cmake --build build --target install
+    - name: Upload test binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: Ubuntu latest - GCC, ${{ matrix.portal.name }}, Static, SDL2
+        path: |
+          build/src/*
+          build/test/*
+
+  build-macos-sdl2:
+
+    name: MacOS latest - Clang, Static, SDL2
+    runs-on: macos-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: brew install sdl2 sdl2_ttf
+    - name: Configure
+      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-Wall -Wextra -Werror -pedantic" -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror -pedantic" -DNFD_BUILD_TESTS=OFF -DNFD_BUILD_SDL2_TESTS=ON ..
+    - name: Build
+      run: cmake --build build --target install
+    - name: Upload test binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: MacOS latest - Clang, Static, SDL2
+        path: |
+          build/src/*
+          build/test/*
+
+  build-windows-sdl2:
+
+    name: Windows latest - MSVC, Static, SDL2
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install pkgconfiglite
+      run: choco install pkgconfiglite
+    - name: Install Dependencies
+      run: vcpkg integrate install && vcpkg install sdl2 sdl2-ttf --triplet=x64-windows-release
+    - name: Configure
+      run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_TARGET_TRIPLET="x64-windows-release" -DNFD_BUILD_TESTS=OFF -DNFD_BUILD_SDL2_TESTS=ON ..
+    - name: Build
+      run: cmake --build build --target install --config Release
+    - name: Upload test binaries
+      uses: actions/upload-artifact@v2
+      with:
+        name: Windows latest - MSVC, Static, SDL2
+        path: |
+          build/src/Release/*
+          build/test/Release/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif ()
 
 option(BUILD_SHARED_LIBS "Build a shared library instead of static" OFF)
 option(NFD_BUILD_TESTS "Build tests for nfd" ${nfd_ROOT_PROJECT})
+option(NFD_BUILD_SDL2_TESTS "Build SDL2 tests for nfd" OFF)
 option(NFD_INSTALL "Generate install target for nfd" ${nfd_ROOT_PROJECT})
 
 set(nfd_PLATFORM Undefined)
@@ -48,6 +49,6 @@ endif()
 
 add_subdirectory(src)
 
-if(${NFD_BUILD_TESTS})
+if(${NFD_BUILD_TESTS} OR ${NFD_BUILD_SDL2_TESTS})
   add_subdirectory(test)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,9 @@ set(TARGET_NAME nfd)
 
 set(PUBLIC_HEADER_FILES
   include/nfd.h
-  include/nfd.hpp)
+  include/nfd.hpp
+  include/nfd_sdl2.h
+  include/nfd_glfw3.h)
 
 set(SOURCE_FILES ${PUBLIC_HEADER_FILES})
 

--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -96,12 +96,31 @@ typedef struct {
 typedef nfdu8filteritem_t nfdnfilteritem_t;
 #endif  // _WIN32
 
+// The native window handle type.
+enum {
+    NFD_WINDOW_HANDLE_TYPE_UNSET = 0,
+    // Windows: handle is HWND (the Windows API typedefs this to void*)
+    NFD_WINDOW_HANDLE_TYPE_WINDOWS = 1,
+    // Cocoa: handle is NSWindow*
+    NFD_WINDOW_HANDLE_TYPE_COCOA = 2,
+    // X11: handle is Window
+    NFD_WINDOW_HANDLE_TYPE_X11 = 3,
+    // Wayland support will be implemented separately in the future
+};
+// The native window handle.  If using a platform abstraction framework (e.g. SDL2), this should be
+// obtained using the corresponding NFD glue header (e.g. nfd_sdl2.h).
+typedef struct {
+    size_t type;  // this is one of the values of the enum above
+    void* handle;
+} nfdwindowhandle_t;
+
 typedef size_t nfdversion_t;
 
 typedef struct {
     const nfdu8filteritem_t* filterList;
     nfdfiltersize_t filterCount;
     const nfdu8char_t* defaultPath;
+    nfdwindowhandle_t parentWindow;
 } nfdopendialogu8args_t;
 
 #ifdef _WIN32
@@ -109,6 +128,7 @@ typedef struct {
     const nfdnfilteritem_t* filterList;
     nfdfiltersize_t filterCount;
     const nfdnchar_t* defaultPath;
+    nfdwindowhandle_t parentWindow;
 } nfdopendialognargs_t;
 #else
 typedef nfdopendialogu8args_t nfdopendialognargs_t;
@@ -119,6 +139,7 @@ typedef struct {
     nfdfiltersize_t filterCount;
     const nfdu8char_t* defaultPath;
     const nfdu8char_t* defaultName;
+    nfdwindowhandle_t parentWindow;
 } nfdsavedialogu8args_t;
 
 #ifdef _WIN32
@@ -127,6 +148,7 @@ typedef struct {
     nfdfiltersize_t filterCount;
     const nfdnchar_t* defaultPath;
     const nfdnchar_t* defaultName;
+    nfdwindowhandle_t parentWindow;
 } nfdsavedialognargs_t;
 #else
 typedef nfdsavedialogu8args_t nfdsavedialognargs_t;
@@ -134,11 +156,13 @@ typedef nfdsavedialogu8args_t nfdsavedialognargs_t;
 
 typedef struct {
     const nfdu8char_t* defaultPath;
+    nfdwindowhandle_t parentWindow;
 } nfdpickfolderu8args_t;
 
 #ifdef _WIN32
 typedef struct {
     const nfdnchar_t* defaultPath;
+    nfdwindowhandle_t parentWindow;
 } nfdpickfoldernargs_t;
 #else
 typedef nfdpickfolderu8args_t nfdpickfoldernargs_t;

--- a/src/include/nfd.hpp
+++ b/src/include/nfd.hpp
@@ -37,16 +37,18 @@ inline void FreePath(nfdnchar_t* outPath) noexcept {
 inline nfdresult_t OpenDialog(nfdnchar_t*& outPath,
                               const nfdnfilteritem_t* filterList = nullptr,
                               nfdfiltersize_t filterCount = 0,
-                              const nfdnchar_t* defaultPath = nullptr) noexcept {
-    const nfdopendialognargs_t args{filterList, filterCount, defaultPath};
+                              const nfdnchar_t* defaultPath = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdopendialognargs_t args{filterList, filterCount, defaultPath, parentWindow};
     return ::NFD_OpenDialogN_With(&outPath, &args);
 }
 
 inline nfdresult_t OpenDialogMultiple(const nfdpathset_t*& outPaths,
                                       const nfdnfilteritem_t* filterList = nullptr,
                                       nfdfiltersize_t filterCount = 0,
-                                      const nfdnchar_t* defaultPath = nullptr) noexcept {
-    const nfdopendialognargs_t args{filterList, filterCount, defaultPath};
+                                      const nfdnchar_t* defaultPath = nullptr,
+                                      nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdopendialognargs_t args{filterList, filterCount, defaultPath, parentWindow};
     return ::NFD_OpenDialogMultipleN_With(&outPaths, &args);
 }
 
@@ -54,20 +56,24 @@ inline nfdresult_t SaveDialog(nfdnchar_t*& outPath,
                               const nfdnfilteritem_t* filterList = nullptr,
                               nfdfiltersize_t filterCount = 0,
                               const nfdnchar_t* defaultPath = nullptr,
-                              const nfdnchar_t* defaultName = nullptr) noexcept {
-    const nfdsavedialognargs_t args{filterList, filterCount, defaultPath, defaultName};
+                              const nfdnchar_t* defaultName = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdsavedialognargs_t args{
+        filterList, filterCount, defaultPath, defaultName, parentWindow};
     return ::NFD_SaveDialogN_With(&outPath, &args);
 }
 
 inline nfdresult_t PickFolder(nfdnchar_t*& outPath,
-                              const nfdnchar_t* defaultPath = nullptr) noexcept {
-    const nfdpickfoldernargs_t args{defaultPath};
+                              const nfdnchar_t* defaultPath = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdpickfoldernargs_t args{defaultPath, parentWindow};
     return ::NFD_PickFolderN_With(&outPath, &args);
 }
 
 inline nfdresult_t PickFolderMultiple(const nfdpathset_t*& outPaths,
-                                      const nfdnchar_t* defaultPath = nullptr) noexcept {
-    const nfdpickfoldernargs_t args{defaultPath};
+                                      const nfdnchar_t* defaultPath = nullptr,
+                                      nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdpickfoldernargs_t args{defaultPath, parentWindow};
     return ::NFD_PickFolderMultipleN_With(&outPaths, &args);
 }
 
@@ -110,16 +116,18 @@ inline void FreePath(nfdu8char_t* outPath) noexcept {
 inline nfdresult_t OpenDialog(nfdu8char_t*& outPath,
                               const nfdu8filteritem_t* filterList = nullptr,
                               nfdfiltersize_t filterCount = 0,
-                              const nfdu8char_t* defaultPath = nullptr) noexcept {
-    const nfdopendialogu8args_t args{filterList, filterCount, defaultPath};
+                              const nfdu8char_t* defaultPath = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdopendialogu8args_t args{filterList, filterCount, defaultPath, parentWindow};
     return ::NFD_OpenDialogU8_With(&outPath, &args);
 }
 
 inline nfdresult_t OpenDialogMultiple(const nfdpathset_t*& outPaths,
                                       const nfdu8filteritem_t* filterList = nullptr,
                                       nfdfiltersize_t filterCount = 0,
-                                      const nfdu8char_t* defaultPath = nullptr) noexcept {
-    const nfdopendialogu8args_t args{filterList, filterCount, defaultPath};
+                                      const nfdu8char_t* defaultPath = nullptr,
+                                      nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdopendialogu8args_t args{filterList, filterCount, defaultPath, parentWindow};
     return ::NFD_OpenDialogMultipleU8_With(&outPaths, &args);
 }
 
@@ -127,20 +135,24 @@ inline nfdresult_t SaveDialog(nfdu8char_t*& outPath,
                               const nfdu8filteritem_t* filterList = nullptr,
                               nfdfiltersize_t filterCount = 0,
                               const nfdu8char_t* defaultPath = nullptr,
-                              const nfdu8char_t* defaultName = nullptr) noexcept {
-    const nfdsavedialogu8args_t args{filterList, filterCount, defaultPath, defaultName};
+                              const nfdu8char_t* defaultName = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdsavedialogu8args_t args{
+        filterList, filterCount, defaultPath, defaultName, parentWindow};
     return ::NFD_SaveDialogU8_With(&outPath, &args);
 }
 
 inline nfdresult_t PickFolder(nfdu8char_t*& outPath,
-                              const nfdu8char_t* defaultPath = nullptr) noexcept {
-    const nfdpickfolderu8args_t args{defaultPath};
+                              const nfdu8char_t* defaultPath = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdpickfolderu8args_t args{defaultPath, parentWindow};
     return ::NFD_PickFolderU8_With(&outPath, &args);
 }
 
 inline nfdresult_t PickFolderMultiple(const nfdpathset_t*& outPaths,
-                                      const nfdu8char_t* defaultPath = nullptr) noexcept {
-    const nfdpickfolderu8args_t args{defaultPath};
+                                      const nfdu8char_t* defaultPath = nullptr,
+                                      nfdwindowhandle_t parentWindow = {}) noexcept {
+    const nfdpickfolderu8args_t args{defaultPath, parentWindow};
     return ::NFD_PickFolderMultipleU8_With(&outPaths, &args);
 }
 
@@ -205,9 +217,10 @@ typedef std::unique_ptr<nfdu8char_t, PathSetPathDeleter<nfdu8char_t>> UniquePath
 inline nfdresult_t OpenDialog(UniquePathN& outPath,
                               const nfdnfilteritem_t* filterList = nullptr,
                               nfdfiltersize_t filterCount = 0,
-                              const nfdnchar_t* defaultPath = nullptr) noexcept {
+                              const nfdnchar_t* defaultPath = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
     nfdnchar_t* out;
-    nfdresult_t res = OpenDialog(out, filterList, filterCount, defaultPath);
+    nfdresult_t res = OpenDialog(out, filterList, filterCount, defaultPath, parentWindow);
     if (res == NFD_OKAY) {
         outPath.reset(out);
     }
@@ -217,9 +230,10 @@ inline nfdresult_t OpenDialog(UniquePathN& outPath,
 inline nfdresult_t OpenDialogMultiple(UniquePathSet& outPaths,
                                       const nfdnfilteritem_t* filterList = nullptr,
                                       nfdfiltersize_t filterCount = 0,
-                                      const nfdnchar_t* defaultPath = nullptr) noexcept {
+                                      const nfdnchar_t* defaultPath = nullptr,
+                                      nfdwindowhandle_t parentWindow = {}) noexcept {
     const nfdpathset_t* out;
-    nfdresult_t res = OpenDialogMultiple(out, filterList, filterCount, defaultPath);
+    nfdresult_t res = OpenDialogMultiple(out, filterList, filterCount, defaultPath, parentWindow);
     if (res == NFD_OKAY) {
         outPaths.reset(out);
     }
@@ -230,9 +244,11 @@ inline nfdresult_t SaveDialog(UniquePathN& outPath,
                               const nfdnfilteritem_t* filterList = nullptr,
                               nfdfiltersize_t filterCount = 0,
                               const nfdnchar_t* defaultPath = nullptr,
-                              const nfdnchar_t* defaultName = nullptr) noexcept {
+                              const nfdnchar_t* defaultName = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
     nfdnchar_t* out;
-    nfdresult_t res = SaveDialog(out, filterList, filterCount, defaultPath, defaultName);
+    nfdresult_t res =
+        SaveDialog(out, filterList, filterCount, defaultPath, defaultName, parentWindow);
     if (res == NFD_OKAY) {
         outPath.reset(out);
     }
@@ -240,9 +256,10 @@ inline nfdresult_t SaveDialog(UniquePathN& outPath,
 }
 
 inline nfdresult_t PickFolder(UniquePathN& outPath,
-                              const nfdnchar_t* defaultPath = nullptr) noexcept {
+                              const nfdnchar_t* defaultPath = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
     nfdnchar_t* out;
-    nfdresult_t res = PickFolder(out, defaultPath);
+    nfdresult_t res = PickFolder(out, defaultPath, parentWindow);
     if (res == NFD_OKAY) {
         outPath.reset(out);
     }
@@ -250,9 +267,10 @@ inline nfdresult_t PickFolder(UniquePathN& outPath,
 }
 
 inline nfdresult_t PickFolderMultiple(UniquePathSet& outPaths,
-                                      const nfdnchar_t* defaultPath = nullptr) noexcept {
+                                      const nfdnchar_t* defaultPath = nullptr,
+                                      nfdwindowhandle_t parentWindow = {}) noexcept {
     const nfdpathset_t* out;
-    nfdresult_t res = PickFolderMultiple(out, defaultPath);
+    nfdresult_t res = PickFolderMultiple(out, defaultPath, parentWindow);
     if (res == NFD_OKAY) {
         outPaths.reset(out);
     }
@@ -263,9 +281,10 @@ inline nfdresult_t PickFolderMultiple(UniquePathSet& outPaths,
 inline nfdresult_t OpenDialog(UniquePathU8& outPath,
                               const nfdu8filteritem_t* filterList = nullptr,
                               nfdfiltersize_t filterCount = 0,
-                              const nfdu8char_t* defaultPath = nullptr) noexcept {
+                              const nfdu8char_t* defaultPath = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
     nfdu8char_t* out;
-    nfdresult_t res = OpenDialog(out, filterList, filterCount, defaultPath);
+    nfdresult_t res = OpenDialog(out, filterList, filterCount, defaultPath, parentWindow);
     if (res == NFD_OKAY) {
         outPath.reset(out);
     }
@@ -275,9 +294,10 @@ inline nfdresult_t OpenDialog(UniquePathU8& outPath,
 inline nfdresult_t OpenDialogMultiple(UniquePathSet& outPaths,
                                       const nfdu8filteritem_t* filterList = nullptr,
                                       nfdfiltersize_t filterCount = 0,
-                                      const nfdu8char_t* defaultPath = nullptr) noexcept {
+                                      const nfdu8char_t* defaultPath = nullptr,
+                                      nfdwindowhandle_t parentWindow = {}) noexcept {
     const nfdpathset_t* out;
-    nfdresult_t res = OpenDialogMultiple(out, filterList, filterCount, defaultPath);
+    nfdresult_t res = OpenDialogMultiple(out, filterList, filterCount, defaultPath, parentWindow);
     if (res == NFD_OKAY) {
         outPaths.reset(out);
     }
@@ -288,9 +308,11 @@ inline nfdresult_t SaveDialog(UniquePathU8& outPath,
                               const nfdu8filteritem_t* filterList = nullptr,
                               nfdfiltersize_t filterCount = 0,
                               const nfdu8char_t* defaultPath = nullptr,
-                              const nfdu8char_t* defaultName = nullptr) noexcept {
+                              const nfdu8char_t* defaultName = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
     nfdu8char_t* out;
-    nfdresult_t res = SaveDialog(out, filterList, filterCount, defaultPath, defaultName);
+    nfdresult_t res =
+        SaveDialog(out, filterList, filterCount, defaultPath, defaultName, parentWindow);
     if (res == NFD_OKAY) {
         outPath.reset(out);
     }
@@ -298,9 +320,10 @@ inline nfdresult_t SaveDialog(UniquePathU8& outPath,
 }
 
 inline nfdresult_t PickFolder(UniquePathU8& outPath,
-                              const nfdu8char_t* defaultPath = nullptr) noexcept {
+                              const nfdu8char_t* defaultPath = nullptr,
+                              nfdwindowhandle_t parentWindow = {}) noexcept {
     nfdu8char_t* out;
-    nfdresult_t res = PickFolder(out, defaultPath);
+    nfdresult_t res = PickFolder(out, defaultPath, parentWindow);
     if (res == NFD_OKAY) {
         outPath.reset(out);
     }
@@ -308,9 +331,10 @@ inline nfdresult_t PickFolder(UniquePathU8& outPath,
 }
 
 inline nfdresult_t PickFolderMultiple(UniquePathSet& outPaths,
-                                      const nfdu8char_t* defaultPath = nullptr) noexcept {
+                                      const nfdu8char_t* defaultPath = nullptr,
+                                      nfdwindowhandle_t parentWindow = {}) noexcept {
     const nfdpathset_t* out;
-    nfdresult_t res = PickFolderMultiple(out, defaultPath);
+    nfdresult_t res = PickFolderMultiple(out, defaultPath, parentWindow);
     if (res == NFD_OKAY) {
         outPaths.reset(out);
     }

--- a/src/include/nfd_glfw3.h
+++ b/src/include/nfd_glfw3.h
@@ -1,0 +1,85 @@
+/*
+  Native File Dialog Extended
+  Repository: https://github.com/btzy/nativefiledialog-extended
+  License: Zlib
+  Authors: Bernard Teo
+
+  This header contains a function to convert a GLFW window handle to a native window handle for
+  passing to NFDe.
+ */
+
+#ifndef _NFD_GLFW3_H
+#define _NFD_GLFW3_H
+
+#include <GLFW/glfw3.h>
+#include <GLFW/glfw3native.h>
+#include <nfd.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#define NFD_INLINE inline
+#else
+#define NFD_INLINE static inline
+#endif  // __cplusplus
+
+/**
+ *  Converts a GLFW window handle to a native window handle that can be passed to NFDe.
+ *  @param sdlWindow The GLFW window handle.
+ *  @param[out] nativeWindow The output native window handle, populated if and only if this function
+ *  returns true.
+ *  @return Either true to indicate success, or false to indicate failure.  It is intended that
+ * users ignore the error and simply pass a value-initialized nfdwindowhandle_t to NFDe if this
+ * function fails. */
+NFD_INLINE bool NFD_GetNativeWindowFromGLFWWindow(GLFWwindow* glfwWindow,
+                                                  nfdwindowhandle_t* nativeWindow) {
+    GLFWerrorfun oldCallback = glfwSetErrorCallback(NULL);
+    bool success = false;
+#if defined(GLFW_EXPOSE_NATIVE_WIN32)
+    if (!success) {
+        const HWND hwnd = glfwGetWin32Window(glfwWindow);
+        if (hwnd) {
+            nativeWindow->type = NFD_WINDOW_HANDLE_TYPE_WINDOWS;
+            nativeWindow->handle = (void*)hwnd;
+            success = true;
+        }
+    }
+#endif
+#if defined(GLFW_EXPOSE_NATIVE_COCOA)
+    if (!success) {
+        const id cocoa_window = glfwGetCocoaWindow(glfwWindow);
+        if (cocoa_window) {
+            nativeWindow->type = NFD_WINDOW_HANDLE_TYPE_COCOA;
+            nativeWindow->handle = (void*)cocoa_window;
+            success = true;
+        }
+    }
+#endif
+#if defined(GLFW_EXPOSE_NATIVE_X11)
+    if (!success) {
+        const Window x11_window = glfwGetX11Window(glfwWindow);
+        if (x11_window != None) {
+            nativeWindow->type = NFD_WINDOW_HANDLE_TYPE_X11;
+            nativeWindow->handle = (void*)x11_window;
+            success = true;
+        }
+    }
+#endif
+#if defined(GLFW_EXPOSE_NATIVE_WAYLAND)
+    // For now we don't support Wayland, but we intend to support it eventually.
+    // Silence the warnings.
+    {
+        (void)glfwWindow;
+        (void)nativeWindow;
+    }
+#endif
+    glfwSetErrorCallback(oldCallback);
+    return success;
+}
+
+#undef NFD_INLINE
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // _NFD_GLFW3_H

--- a/src/include/nfd_sdl2.h
+++ b/src/include/nfd_sdl2.h
@@ -1,0 +1,76 @@
+/*
+  Native File Dialog Extended
+  Repository: https://github.com/btzy/nativefiledialog-extended
+  License: Zlib
+  Authors: Bernard Teo
+
+  This header contains a function to convert an SDL window handle to a native window handle for
+  passing to NFDe.
+
+  This is meant to be used with SDL2, but if there are incompatibilities with future SDL versions,
+  we can conditionally compile based on SDL_MAJOR_VERSION.
+ */
+
+#ifndef _NFD_SDL2_H
+#define _NFD_SDL2_H
+
+#include <SDL_error.h>
+#include <SDL_syswm.h>
+#include <nfd.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#define NFD_INLINE inline
+#else
+#define NFD_INLINE static inline
+#endif  // __cplusplus
+
+/**
+ *  Converts an SDL window handle to a native window handle that can be passed to NFDe.
+ *  @param sdlWindow The SDL window handle.
+ *  @param[out] nativeWindow The output native window handle, populated if and only if this function
+ *  returns true.
+ *  @return Either true to indicate success, or false to indicate failure.  If false is returned,
+ * you can call SDL_GetError() for more information.  However, it is intended that users ignore the
+ * error and simply pass a value-initialized nfdwindowhandle_t to NFDe if this function fails. */
+NFD_INLINE bool NFD_GetNativeWindowFromSDLWindow(SDL_Window* sdlWindow,
+                                                 nfdwindowhandle_t* nativeWindow) {
+    SDL_SysWMinfo info;
+    SDL_VERSION(&info.version);
+    if (!SDL_GetWindowWMInfo(sdlWindow, &info)) {
+        return false;
+    }
+    switch (info.subsystem) {
+#if defined(SDL_VIDEO_DRIVER_WINDOWS)
+        case SDL_SYSWM_WINDOWS:
+            nativeWindow->type = NFD_WINDOW_HANDLE_TYPE_WINDOWS;
+            nativeWindow->handle = (void*)info.info.win.window;
+            return true;
+#endif
+#if defined(SDL_VIDEO_DRIVER_COCOA)
+        case SDL_SYSWM_COCOA:
+            nativeWindow->type = NFD_WINDOW_HANDLE_TYPE_COCOA;
+            nativeWindow->handle = (void*)info.info.cocoa.window;
+            return true;
+#endif
+#if defined(SDL_VIDEO_DRIVER_X11)
+        case SDL_SYSWM_X11:
+            nativeWindow->type = NFD_WINDOW_HANDLE_TYPE_X11;
+            nativeWindow->handle = (void*)info.info.x11.window;
+            return true;
+#endif
+        default:
+            // Silence the warning in case we are not using a supported backend.
+            (void)nativeWindow;
+            SDL_SetError("Unsupported native window type.");
+            return false;
+    }
+}
+
+#undef NFD_INLINE
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // _NFD_SDL2_H

--- a/src/nfd_cocoa.m
+++ b/src/nfd_cocoa.m
@@ -174,6 +174,13 @@ static nfdresult_t CopyUtf8String(const char* utf8Str, nfdnchar_t** out) {
     return NFD_ERROR;
 }
 
+static NSWindow* GetNativeWindowHandle(const nfdwindowhandle_t* parentWindow) {
+    if (parentWindow->type != NFD_WINDOW_HANDLE_TYPE_COCOA) {
+        return NULL;
+    }
+    return (NSWindow*)parentWindow->handle;
+}
+
 /* public */
 
 const char* NFD_GetError(void) {
@@ -230,7 +237,12 @@ nfdresult_t NFD_OpenDialogN_With_Impl(nfdversion_t version,
 
     nfdresult_t result = NFD_CANCEL;
     @autoreleasepool {
-        NSWindow* keyWindow = [[NSApplication sharedApplication] keyWindow];
+        NSWindow* keyWindow = GetNativeWindowHandle(&args->parentWindow);
+        if (keyWindow) {
+            [keyWindow makeKeyAndOrderFront:nil];
+        } else {
+            keyWindow = [[NSApplication sharedApplication] keyWindow];
+        }
 
         NSOpenPanel* dialog = [NSOpenPanel openPanel];
         [dialog setAllowsMultipleSelection:NO];
@@ -285,7 +297,12 @@ nfdresult_t NFD_OpenDialogMultipleN_With_Impl(nfdversion_t version,
 
     nfdresult_t result = NFD_CANCEL;
     @autoreleasepool {
-        NSWindow* keyWindow = [[NSApplication sharedApplication] keyWindow];
+        NSWindow* keyWindow = GetNativeWindowHandle(&args->parentWindow);
+        if (keyWindow) {
+            [keyWindow makeKeyAndOrderFront:nil];
+        } else {
+            keyWindow = [[NSApplication sharedApplication] keyWindow];
+        }
 
         NSOpenPanel* dialog = [NSOpenPanel openPanel];
         [dialog setAllowsMultipleSelection:YES];
@@ -347,7 +364,12 @@ nfdresult_t NFD_SaveDialogN_With_Impl(nfdversion_t version,
 
     nfdresult_t result = NFD_CANCEL;
     @autoreleasepool {
-        NSWindow* keyWindow = [[NSApplication sharedApplication] keyWindow];
+        NSWindow* keyWindow = GetNativeWindowHandle(&args->parentWindow);
+        if (keyWindow) {
+            [keyWindow makeKeyAndOrderFront:nil];
+        } else {
+            keyWindow = [[NSApplication sharedApplication] keyWindow];
+        }
 
         NSSavePanel* dialog = [NSSavePanel savePanel];
         [dialog setExtensionHidden:NO];
@@ -404,7 +426,12 @@ nfdresult_t NFD_PickFolderN_With_Impl(nfdversion_t version,
 
     nfdresult_t result = NFD_CANCEL;
     @autoreleasepool {
-        NSWindow* keyWindow = [[NSApplication sharedApplication] keyWindow];
+        NSWindow* keyWindow = GetNativeWindowHandle(&args->parentWindow);
+        if (keyWindow) {
+            [keyWindow makeKeyAndOrderFront:nil];
+        } else {
+            keyWindow = [[NSApplication sharedApplication] keyWindow];
+        }
 
         NSOpenPanel* dialog = [NSOpenPanel openPanel];
         [dialog setAllowsMultipleSelection:NO];
@@ -451,7 +478,12 @@ nfdresult_t NFD_PickFolderMultipleN_With_Impl(nfdversion_t version,
 
     nfdresult_t result = NFD_CANCEL;
     @autoreleasepool {
-        NSWindow* keyWindow = [[NSApplication sharedApplication] keyWindow];
+        NSWindow* keyWindow = GetNativeWindowHandle(&args->parentWindow);
+        if (keyWindow) {
+            [keyWindow makeKeyAndOrderFront:nil];
+        } else {
+            keyWindow = [[NSApplication sharedApplication] keyWindow];
+        }
 
         NSOpenPanel* dialog = [NSOpenPanel openPanel];
         [dialog setAllowsMultipleSelection:YES];

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -284,6 +284,13 @@ nfdresult_t AddOptions(IFileDialog* dialog, FILEOPENDIALOGOPTIONS options) {
     }
     return NFD_OKAY;
 }
+
+HWND GetNativeWindowHandle(const nfdwindowhandle_t& parentWindow) {
+    if (parentWindow.type != NFD_WINDOW_HANDLE_TYPE_WINDOWS) {
+        return nullptr;
+    }
+    return static_cast<HWND>(parentWindow.handle);
+}
 }  // namespace
 
 const char* NFD_GetError(void) {
@@ -385,7 +392,7 @@ nfdresult_t NFD_OpenDialogN_With_Impl(nfdversion_t version,
     }
 
     // Show the dialog.
-    result = fileOpenDialog->Show(nullptr);
+    result = fileOpenDialog->Show(GetNativeWindowHandle(args->parentWindow));
     if (SUCCEEDED(result)) {
         // Get the file name
         ::IShellItem* psiResult;
@@ -469,7 +476,7 @@ nfdresult_t NFD_OpenDialogMultipleN_With_Impl(nfdversion_t version,
     }
 
     // Show the dialog.
-    result = fileOpenDialog->Show(nullptr);
+    result = fileOpenDialog->Show(GetNativeWindowHandle(args->parentWindow));
     if (SUCCEEDED(result)) {
         ::IShellItemArray* shellItems;
         result = fileOpenDialog->GetResults(&shellItems);
@@ -552,7 +559,7 @@ nfdresult_t NFD_SaveDialogN_With_Impl(nfdversion_t version,
     }
 
     // Show the dialog.
-    result = fileSaveDialog->Show(nullptr);
+    result = fileSaveDialog->Show(GetNativeWindowHandle(args->parentWindow));
     if (SUCCEEDED(result)) {
         // Get the file name
         ::IShellItem* psiResult;
@@ -618,7 +625,7 @@ nfdresult_t NFD_PickFolderN_With_Impl(nfdversion_t version,
     }
 
     // Show the dialog to the user
-    const HRESULT result = fileOpenDialog->Show(nullptr);
+    const HRESULT result = fileOpenDialog->Show(GetNativeWindowHandle(args->parentWindow));
     if (result == HRESULT_FROM_WIN32(ERROR_CANCELLED)) {
         return NFD_CANCEL;
     } else if (!SUCCEEDED(result)) {
@@ -685,7 +692,7 @@ nfdresult_t NFD_PickFolderMultipleN_With_Impl(nfdversion_t version,
     }
 
     // Show the dialog.
-    const HRESULT result = fileOpenDialog->Show(nullptr);
+    const HRESULT result = fileOpenDialog->Show(GetNativeWindowHandle(args->parentWindow));
     if (SUCCEEDED(result)) {
         ::IShellItemArray* shellItems;
         if (!SUCCEEDED(fileOpenDialog->GetResults(&shellItems))) {
@@ -948,7 +955,7 @@ nfdresult_t NFD_OpenDialogU8_With_Impl(nfdversion_t version,
     // call the native function
     nfdnchar_t* outPathN;
     const nfdopendialognargs_t argsN{
-        filterItemsNGuard.data, args->filterCount, defaultPathNGuard.data};
+        filterItemsNGuard.data, args->filterCount, defaultPathNGuard.data, args->parentWindow};
     nfdresult_t res = NFD_OpenDialogN_With_Impl(NFD_INTERFACE_VERSION, &outPathN, &argsN);
 
     if (res != NFD_OKAY) {
@@ -996,7 +1003,7 @@ nfdresult_t NFD_OpenDialogMultipleU8_With_Impl(nfdversion_t version,
 
     // call the native function
     const nfdopendialognargs_t argsN{
-        filterItemsNGuard.data, args->filterCount, defaultPathNGuard.data};
+        filterItemsNGuard.data, args->filterCount, defaultPathNGuard.data, args->parentWindow};
     return NFD_OpenDialogMultipleN_With_Impl(NFD_INTERFACE_VERSION, outPaths, &argsN);
 }
 
@@ -1039,8 +1046,11 @@ nfdresult_t NFD_SaveDialogU8_With_Impl(nfdversion_t version,
 
     // call the native function
     nfdnchar_t* outPathN;
-    const nfdsavedialognargs_t argsN{
-        filterItemsNGuard.data, args->filterCount, defaultPathNGuard.data, defaultNameNGuard.data};
+    const nfdsavedialognargs_t argsN{filterItemsNGuard.data,
+                                     args->filterCount,
+                                     defaultPathNGuard.data,
+                                     defaultNameNGuard.data,
+                                     args->parentWindow};
     nfdresult_t res = NFD_SaveDialogN_With_Impl(NFD_INTERFACE_VERSION, &outPathN, &argsN);
 
     if (res != NFD_OKAY) {
@@ -1077,7 +1087,7 @@ nfdresult_t NFD_PickFolderU8_With_Impl(nfdversion_t version,
 
     // call the native function
     nfdnchar_t* outPathN;
-    const nfdpickfoldernargs_t argsN{defaultPathNGuard.data};
+    const nfdpickfoldernargs_t argsN{defaultPathNGuard.data, args->parentWindow};
     nfdresult_t res = NFD_PickFolderN_With_Impl(NFD_INTERFACE_VERSION, &outPathN, &argsN);
 
     if (res != NFD_OKAY) {
@@ -1114,7 +1124,7 @@ nfdresult_t NFD_PickFolderMultipleU8_With_Impl(nfdversion_t version,
     NormalizePathSeparator(defaultPathNGuard.data);
 
     // call the native function
-    const nfdpickfoldernargs_t argsN{defaultPathNGuard.data};
+    const nfdpickfoldernargs_t argsN{defaultPathNGuard.data, args->parentWindow};
     return NFD_PickFolderMultipleN_With_Impl(NFD_INTERFACE_VERSION, outPaths, &argsN);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,31 +1,46 @@
+if(${NFD_BUILD_TESTS})
+  set(TEST_LIST
+    test_opendialog.c
+    test_opendialog_cpp.cpp
+    test_opendialog_native.c
+    test_opendialog_with.c
+    test_opendialog_native_with.c
+    test_opendialogmultiple.c
+    test_opendialogmultiple_cpp.cpp
+    test_opendialogmultiple_native.c
+    test_opendialogmultiple_enum.c
+    test_opendialogmultiple_enum_native.c
+    test_pickfolder.c
+    test_pickfolder_cpp.cpp
+    test_pickfolder_native.c
+    test_pickfolder_with.c
+    test_pickfolder_native_with.c
+    test_pickfoldermultiple.c
+    test_pickfoldermultiple_native.c
+    test_savedialog.c
+    test_savedialog_native.c
+    test_savedialog_with.c
+    test_savedialog_native_with.c)
 
-set(TEST_LIST
-  test_opendialog.c
-  test_opendialog_cpp.cpp
-  test_opendialog_native.c
-  test_opendialog_with.c
-  test_opendialog_native_with.c
-  test_opendialogmultiple.c
-  test_opendialogmultiple_cpp.cpp
-  test_opendialogmultiple_native.c
-  test_opendialogmultiple_enum.c
-  test_opendialogmultiple_enum_native.c
-  test_pickfolder.c
-  test_pickfolder_cpp.cpp
-  test_pickfolder_native.c
-  test_pickfolder_with.c
-  test_pickfolder_native_with.c
-  test_pickfoldermultiple.c
-  test_pickfoldermultiple_native.c
-  test_savedialog.c
-  test_savedialog_native.c
-  test_savedialog_with.c
-  test_savedialog_native_with.c)
-  
-foreach (TEST ${TEST_LIST})
-  string(REPLACE "." "_" CLEAN_TEST_NAME ${TEST})
-  add_executable(${CLEAN_TEST_NAME}
-    ${TEST})
-  target_link_libraries(${CLEAN_TEST_NAME}
-    PUBLIC nfd)
-endforeach()
+  foreach (TEST ${TEST_LIST})
+    string(REPLACE "." "_" CLEAN_TEST_NAME ${TEST})
+    add_executable(${CLEAN_TEST_NAME}
+      ${TEST})
+    target_link_libraries(${CLEAN_TEST_NAME}
+      PRIVATE nfd)
+  endforeach()
+endif()
+
+if(${NFD_BUILD_SDL2_TESTS})
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(SDL2 REQUIRED sdl2 SDL2_ttf)
+  if(WIN32)
+    add_executable(test_sdl2 WIN32 test_sdl.c test_sdl.manifest)
+  else()
+    add_executable(test_sdl2 test_sdl.c)
+  endif()
+  target_link_libraries(test_sdl2 PRIVATE nfd)
+  target_include_directories(test_sdl2 PRIVATE ${SDL2_INCLUDE_DIRS})
+  target_link_libraries(test_sdl2 PRIVATE ${SDL2_LINK_LIBRARIES})
+  target_compile_options(test_sdl2 PUBLIC ${SDL2_CFLAGS_OTHER})
+endif()

--- a/test/test_sdl.c
+++ b/test/test_sdl.c
@@ -1,0 +1,410 @@
+#define SDL_MAIN_HANDLED
+#include <SDL.h>
+#include <SDL_ttf.h>
+#include <nfd.h>
+#include <nfd_sdl2.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Small program meant to demonstrate and test nfd_sdl2.h with SDL2.  Note that it quits immediately
+// when it encounters an error, without calling the opposite destroy/quit function.  A real-world
+// application should call destroy/quit appropriately.
+
+void show_error(const char* message, SDL_Window* window) {
+    if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Error", message, window) != 0) {
+        printf("SDL_ShowSimpleMessageBox failed: %s\n", SDL_GetError());
+        return;
+    }
+}
+
+void show_path(const char* path, SDL_Window* window) {
+    if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Success", path, window) != 0) {
+        printf("SDL_ShowSimpleMessageBox failed: %s\n", SDL_GetError());
+        return;
+    }
+}
+
+void show_paths(const nfdpathset_t* paths, SDL_Window* window) {
+    size_t num_chars = 0;
+
+    nfdpathsetsize_t num_paths;
+    if (NFD_PathSet_GetCount(paths, &num_paths) != NFD_OKAY) {
+        printf("NFD_PathSet_GetCount failed: %s\n", NFD_GetError());
+        return;
+    }
+
+    nfdpathsetsize_t i;
+    for (i = 0; i != num_paths; ++i) {
+        char* path;
+        if (NFD_PathSet_GetPathU8(paths, i, &path) != NFD_OKAY) {
+            printf("NFD_PathSet_GetPathU8 failed: %s\n", NFD_GetError());
+            return;
+        }
+        num_chars += strlen(path) + 1;
+        NFD_PathSet_FreePathU8(path);
+    }
+
+    char* message = malloc(num_chars);
+    message[0] = '\0';
+
+    for (i = 0; i != num_paths; ++i) {
+        if (i != 0) {
+            strcat(message, "\n");
+        }
+        char* path;
+        if (NFD_PathSet_GetPathU8(paths, i, &path) != NFD_OKAY) {
+            printf("NFD_PathSet_GetPathU8 failed: %s\n", NFD_GetError());
+            free(message);
+            return;
+        }
+        strcat(message, path);
+        NFD_PathSet_FreePathU8(path);
+    }
+
+    if (SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_INFORMATION, "Success", message, window) != 0) {
+        printf("SDL_ShowSimpleMessageBox failed: %s\n", SDL_GetError());
+        free(message);
+        return;
+    }
+
+    free(message);
+}
+
+void set_native_window(SDL_Window* sdlWindow, nfdwindowhandle_t* nativeWindow) {
+    if (!NFD_GetNativeWindowFromSDLWindow(sdlWindow, nativeWindow)) {
+        printf("NFD_GetNativeWindowFromSDLWindow failed: %s\n", SDL_GetError());
+    }
+}
+
+void opendialog_handler(SDL_Window* window) {
+    char* path;
+    nfdopendialogu8args_t args = {0};
+    set_native_window(window, &args.parentWindow);
+    const nfdresult_t res = NFD_OpenDialogU8_With(&path, &args);
+    switch (res) {
+        case NFD_OKAY:
+            show_path(path, window);
+            NFD_FreePathU8(path);
+            break;
+        case NFD_ERROR:
+            show_error(NFD_GetError(), window);
+            break;
+        default:
+            break;
+    }
+}
+
+void opendialogmultiple_handler(SDL_Window* window) {
+    const nfdpathset_t* paths;
+    nfdopendialogu8args_t args = {0};
+    set_native_window(window, &args.parentWindow);
+    const nfdresult_t res = NFD_OpenDialogMultipleU8_With(&paths, &args);
+    switch (res) {
+        case NFD_OKAY:
+            show_paths(paths, window);
+            NFD_PathSet_Free(paths);
+            break;
+        case NFD_ERROR:
+            show_error(NFD_GetError(), window);
+            break;
+        default:
+            break;
+    }
+}
+
+void savedialog_handler(SDL_Window* window) {
+    char* path;
+    nfdsavedialogu8args_t args = {0};
+    set_native_window(window, &args.parentWindow);
+    const nfdresult_t res = NFD_SaveDialogU8_With(&path, &args);
+    switch (res) {
+        case NFD_OKAY:
+            show_path(path, window);
+            NFD_FreePathU8(path);
+            break;
+        case NFD_ERROR:
+            show_error(NFD_GetError(), window);
+            break;
+        default:
+            break;
+    }
+}
+
+void pickfolder_handler(SDL_Window* window) {
+    char* path;
+    nfdpickfolderu8args_t args = {0};
+    set_native_window(window, &args.parentWindow);
+    const nfdresult_t res = NFD_PickFolderU8_With(&path, &args);
+    switch (res) {
+        case NFD_OKAY:
+            show_path(path, window);
+            NFD_FreePathU8(path);
+            break;
+        case NFD_ERROR:
+            show_error(NFD_GetError(), window);
+            break;
+        default:
+            break;
+    }
+}
+
+void pickfoldermultiple_handler(SDL_Window* window) {
+    const nfdpathset_t* paths;
+    nfdpickfolderu8args_t args = {0};
+    set_native_window(window, &args.parentWindow);
+    const nfdresult_t res = NFD_PickFolderMultipleU8_With(&paths, &args);
+    switch (res) {
+        case NFD_OKAY:
+            show_paths(paths, window);
+            NFD_PathSet_Free(paths);
+            break;
+        case NFD_ERROR:
+            show_error(NFD_GetError(), window);
+            break;
+        default:
+            break;
+    }
+}
+
+#if defined(_WIN32)
+const char font_file[] = "C:\\Windows\\Fonts\\calibri.ttf";
+#elif defined(__APPLE__)
+const char font_file[] = "/System/Library/Fonts/SFNS.ttf";
+#else
+const char font_file[] = "/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf";
+#endif
+
+#define NUM_STATES 3
+#define NUM_BUTTONS 5
+const char* button_text[NUM_BUTTONS] = {"Open File",
+                                        "Open Files",
+                                        "Save File",
+                                        "Select Folder",
+                                        "Select Folders"};
+const int BUTTON_WIDTH = 400;
+const int BUTTON_HEIGHT = 40;
+
+void (*button_handler[NUM_BUTTONS])(SDL_Window*) = {&opendialog_handler,
+                                                    &opendialogmultiple_handler,
+                                                    &savedialog_handler,
+                                                    &pickfolder_handler,
+                                                    &pickfoldermultiple_handler};
+
+#ifdef _WIN32
+int WINAPI WinMain(void)
+#else
+int main(void)
+#endif
+{
+#ifdef _WIN32
+    // Enable DPI awareness on Windows
+    SDL_SetHint("SDL_HINT_WINDOWS_DPI_AWARENESS", "permonitorv2");
+    SDL_SetHint("SDL_HINT_WINDOWS_DPI_SCALING", "1");
+#endif
+
+    // initialize SDL
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        printf("SDL_Init failed: %s\n", SDL_GetError());
+        return 0;
+    }
+
+    // initialize SDL_ttf
+    if (TTF_Init() != 0) {
+        printf("TTF_Init failed: %s\n", TTF_GetError());
+        return 0;
+    }
+
+    // initialize NFD
+    if (NFD_Init() != NFD_OKAY) {
+        printf("NFD_Init failed: %s\n", NFD_GetError());
+        return 0;
+    }
+
+    // create window
+    SDL_Window* const window = SDL_CreateWindow("Welcome",
+                                                SDL_WINDOWPOS_UNDEFINED,
+                                                SDL_WINDOWPOS_UNDEFINED,
+                                                BUTTON_WIDTH,
+                                                BUTTON_HEIGHT * NUM_BUTTONS,
+                                                SDL_WINDOW_ALLOW_HIGHDPI);
+    if (!window) {
+        printf("SDL_CreateWindow failed: %s\n", SDL_GetError());
+        return 0;
+    }
+
+    // create renderer
+    SDL_Renderer* const renderer =
+        SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    if (!renderer) {
+        printf("SDL_CreateRenderer failed: %s\n", SDL_GetError());
+        return 0;
+    }
+
+    // prepare the buttons and handlers
+    SDL_Texture* textures_normal[NUM_BUTTONS][NUM_STATES];
+
+    TTF_Font* const font = TTF_OpenFont(font_file, 20);
+    if (!font) {
+        printf("TTF_OpenFont failed: %s\n", TTF_GetError());
+        return 0;
+    }
+
+    const SDL_Color back_color[NUM_STATES] = {{0, 0, 0, SDL_ALPHA_OPAQUE},
+                                              {51, 51, 51, SDL_ALPHA_OPAQUE},
+                                              {102, 102, 102, SDL_ALPHA_OPAQUE}};
+    const SDL_Color text_color = {255, 255, 255, SDL_ALPHA_OPAQUE};
+    const uint8_t text_alpha[NUM_STATES] = {153, 204, 255};
+
+    for (size_t i = 0; i != NUM_BUTTONS; ++i) {
+        SDL_Surface* const text_surface = TTF_RenderUTF8_Blended(font, button_text[i], text_color);
+        if (!text_surface) {
+            printf("TTF_RenderUTF8_Blended failed: %s\n", TTF_GetError());
+            return 0;
+        }
+
+        if (SDL_SetSurfaceBlendMode(text_surface, SDL_BLENDMODE_BLEND) != 0) {
+            printf("SDL_SetSurfaceBlendMode failed: %s\n", SDL_GetError());
+            return 0;
+        }
+
+        for (size_t j = 0; j != NUM_STATES; ++j) {
+            SDL_Surface* button_surface =
+                SDL_CreateRGBSurface(0, BUTTON_WIDTH, BUTTON_HEIGHT, 32, 0, 0, 0, 0);
+            if (!button_surface) {
+                printf("SDL_CreateRGBSurface failed: %s\n", SDL_GetError());
+                return 0;
+            }
+
+            if (SDL_FillRect(button_surface,
+                             NULL,
+                             SDL_MapRGBA(button_surface->format,
+                                         back_color[j].r,
+                                         back_color[j].g,
+                                         back_color[j].b,
+                                         back_color[j].a)) != 0) {
+                printf("SDL_FillRect failed: %s\n", SDL_GetError());
+                return 0;
+            }
+
+            SDL_SetSurfaceAlphaMod(text_surface, text_alpha[j]);
+
+            SDL_Rect dstrect = {(BUTTON_WIDTH - text_surface->w) / 2,
+                                (BUTTON_HEIGHT - text_surface->h) / 2,
+                                text_surface->w,
+                                text_surface->h};
+            if (SDL_BlitSurface(text_surface, NULL, button_surface, &dstrect) != 0) {
+                printf("SDL_BlitSurface failed: %s\n", SDL_GetError());
+                return 0;
+            }
+
+            SDL_Texture* const texture = SDL_CreateTextureFromSurface(renderer, button_surface);
+            if (!texture) {
+                printf("SDL_CreateTextureFromSurface failed: %s\n", SDL_GetError());
+                return 0;
+            }
+
+            SDL_FreeSurface(button_surface);
+
+            textures_normal[i][j] = texture;
+        }
+
+        SDL_FreeSurface(text_surface);
+    }
+
+    TTF_CloseFont(font);
+
+    // event loop
+    bool quit = false;
+    size_t button_index = (size_t)-1;
+    bool pressed = false;
+    do {
+        // render
+        for (size_t i = 0; i != NUM_BUTTONS; ++i) {
+            const SDL_Rect rect = {0, (int)i * BUTTON_HEIGHT, BUTTON_WIDTH, BUTTON_HEIGHT};
+            SDL_RenderCopy(
+                renderer, textures_normal[i][button_index == i ? pressed ? 2 : 1 : 0], NULL, &rect);
+        }
+        SDL_RenderPresent(renderer);
+
+        // process events
+        SDL_Event event;
+        if (SDL_WaitEvent(&event) == 0) {
+            printf("SDL_WaitEvent failed: %s\n", SDL_GetError());
+            return 0;
+        }
+        do {
+            switch (event.type) {
+                case SDL_QUIT: {
+                    quit = true;
+                    break;
+                }
+                case SDL_WINDOWEVENT: {
+                    switch (event.window.event) {
+                        case SDL_WINDOWEVENT_CLOSE:
+                            quit = true;
+                            break;
+                        case SDL_WINDOWEVENT_LEAVE:
+                            button_index = (size_t)-1;
+                            break;
+                    }
+                    break;
+                }
+                case SDL_MOUSEMOTION: {
+                    if (event.motion.x < 0 || event.motion.x >= BUTTON_WIDTH ||
+                        event.motion.y < 0) {
+                        button_index = (size_t)-1;
+                        break;
+                    }
+                    const int index = event.motion.y / BUTTON_HEIGHT;
+                    if (index < 0 || index >= NUM_BUTTONS) {
+                        button_index = (size_t)-1;
+                        break;
+                    }
+                    button_index = index;
+                    pressed = event.motion.state & SDL_BUTTON(1);
+                    break;
+                }
+                case SDL_MOUSEBUTTONDOWN: {
+                    if (event.button.button == 1) {
+                        pressed = true;
+                    }
+                    break;
+                }
+                case SDL_MOUSEBUTTONUP: {
+                    if (event.button.button == 1) {
+                        pressed = false;
+                        if (button_index != (size_t)-1) {
+                            (*button_handler[button_index])(window);
+                        }
+                    }
+                    break;
+                }
+            }
+        } while (SDL_PollEvent(&event) != 0);
+    } while (!quit);
+
+    // destroy textures
+    for (size_t i = 0; i != NUM_BUTTONS; ++i) {
+        for (size_t j = 0; j != NUM_STATES; ++j) {
+            SDL_DestroyTexture(textures_normal[i][j]);
+        }
+    }
+
+    // destroy renderer
+    SDL_DestroyRenderer(renderer);
+
+    // destroy window
+    SDL_DestroyWindow(window);
+
+    // quit NFD
+    NFD_Quit();
+
+    // quit SDL_ttf
+    TTF_Quit();
+
+    // quit SDL
+    SDL_Quit();
+
+    return 0;
+}

--- a/test/test_sdl.manifest
+++ b/test/test_sdl.manifest
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"
+    xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <assemblyIdentity
+        version="1.0.0.0"
+        processorArchitecture="*"
+        name="CompanyName.ProductName.YourApp"
+        type="win32"
+    />
+    <asmv3:application>
+        <asmv3:windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+    <description>Example application for NFDe.</description>
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity
+                type="win32"
+                name="Microsoft.Windows.Common-Controls"
+                version="6.0.0.0"
+                processorArchitecture="*"
+                publicKeyToken="6595b64144ccf1df"
+                language="*"
+            />
+        </dependentAssembly>
+    </dependency>
+</assembly>


### PR DESCRIPTION
On at least Windows and Linux (both GTK and Portal), the dialog misbehaves in a noticeable way when the parent window handle is not passed to the underlying platform-specific API.  The macOS (Cocoa) backend guesses the parent from the key window (the window receiving keyboard events).  The parent window handle, however, is platform-specific (and on Linux, also specific to the windowing system) (e.g. `HWND` on Windows, `NSWindow*` on macOS, `Window` on X11, `wl_surface*` on Wayland), which means that NFDe necessarily needs to expose an API that is not fully platform-agnostic, if it is to allow users to pass it the parent window handle.

This is acceptable if the user is not using any platform abstraction framework (e.g. SDL2 or GLFW), since the user must already be writing platform-specific code.

However, a significant benefit of NFDe is realised when the user also uses a platform abstraction framework, as it allows them to write code in a platform-agnostic manner throughout their codebase.  It would be unwieldy if they had to write platform-specific code to glue NFDe to their framework.

Platform abstraction frameworks typically define their own type to represent a window handle (e.g `SDL_Window*` on SDL2, `GLFWwindow*` on GLFW), and it is possible to get the native window handle from it (via platform-specific APIs).  By implementing the conversions from the window type as an optional component of NFDe, it frees the user from having to write their own glue code.

This PR adds a new argument to all the main APIs (OpenFile, OpenFileMultiple, SaveFile, PickFolder, PickFolderMultiple) to take a native window handle, which can be a Windows, macOS, or X11 handle.  Wayland is not yet supported as it looks complicated and documentation is scant, though it will probably be implemented in the future.  This PR also implements framework-specific window handle conversion functions in optional separate headers.

Resolves #90.
Resolves #126.