### PR TITLE
Build: Add alias target for dependent project CMake consumption

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,9 @@ endif()
 # Define the library
 add_library(${TARGET_NAME} ${SOURCE_FILES})
 
+# Define alias library to fail early in dependent projects
+add_library(${TARGET_NAME}::${TARGET_NAME} ALIAS ${TARGET_NAME})
+
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(${TARGET_NAME} PRIVATE NFD_EXPORT INTERFACE NFD_SHARED)
 endif ()


### PR DESCRIPTION
Add a target `nfd::nfd` as an alias for the library `nfd`.

This naming convention is common in other CMake projects. The presence of `::` in the identifier results in fail-fast behavior; when a user calls `target_link_libraries` or similar, `nfd::nfd` MUST be an existing target at configure time, but `nfd` might have been a system library. As a result, the latter would appear to work until the linker fails to find a library by that name.

This is not a breaking change - plain `nfd` is still accessible.