### PR TITLE
Windows: Add NFD_OVERRIDE_RECENT_WITH_DEFAULT flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ typedef struct {
 ```
 
 - `filterList` and `filterCount`: Set these to customize the file filter (it appears as a dropdown menu on Windows and Linux, but simply hides files on macOS).  Set `filterList` to a pointer to the start of the array of filter items and `filterCount` to the number of filter items in that array.  See the "File Filter Syntax" section below for details.
-- `defaultPath`: Set this to the default folder that the dialog should open to (on Windows, if there is a recently used folder, it opens to that folder instead of the folder you pass, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` flag is set to 1).
+- `defaultPath`: Set this to the default folder that the dialog should open to (on Windows, if there is a recently used folder, it opens to that folder instead of the folder you pass, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` flag is set to ON).
 - `defaultName`: (For SaveDialog only) Set this to the file name that should be pre-filled on the dialog.
 - `parentWindow`: Set this to the native window handle of the parent of this dialog.  See the "Usage with a Platform Abstraction Framework" section for details.  It is also possible to pass a handle even if you do not use a platform abstraction framework.
 
@@ -257,7 +257,7 @@ A wildcard filter is always added to every dialog.
 
 *Note 3: On Linux, the file extension is appended (if missing) when the user presses down the "Save" button.  The appended file extension will remain visible to the user, even if an overwrite prompt is shown and the user then presses "Cancel".*
 
-*Note 4: On Windows, the default folder parameter is only used if there is no recently used folder available, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` flag is set to 1.  Otherwise, the default folder will be the folder that was last used.  Internally, the Windows implementation calls [IFileDialog::SetDefaultFolder(IShellItem)](https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultfolder).  This is usual Windows behaviour and users expect it.*
+*Note 4: On Windows, the default folder parameter is only used if there is no recently used folder available, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` flag is set to ON.  Otherwise, the default folder will be the folder that was last used.  Internally, the Windows implementation calls [IFileDialog::SetDefaultFolder(IShellItem)](https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultfolder).  This is usual Windows behaviour and users expect it.*
 
 ## Iterating Over PathSets
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![GitHub Actions](https://github.com/btzy/nativefiledialog-extended/workflows/build/badge.svg)
 
-A small C library with that portably invokes native file open, folder select and file save dialogs.  Write dialog code once and have it pop up native dialogs on all supported platforms.  Avoid linking large dependencies like wxWidgets and Qt.
+A small C library that portably invokes native file open, folder select and file save dialogs.  Write dialog code once and have it pop up native dialogs on all supported platforms.  Avoid linking large dependencies like wxWidgets and Qt.
 
 This library is based on Michael Labbe's Native File Dialog ([mlabbe/nativefiledialog](https://github.com/mlabbe/nativefiledialog)).
 
@@ -223,7 +223,7 @@ typedef struct {
 ```
 
 - `filterList` and `filterCount`: Set these to customize the file filter (it appears as a dropdown menu on Windows and Linux, but simply hides files on macOS).  Set `filterList` to a pointer to the start of the array of filter items and `filterCount` to the number of filter items in that array.  See the "File Filter Syntax" section below for details.
-- `defaultPath`: Set this to the default folder that the dialog should open to (on Windows, if there is a recently used folder, it opens to that folder instead of the folder you pass).
+- `defaultPath`: Set this to the default folder that the dialog should open to (on Windows, if there is a recently used folder, it opens to that folder instead of the folder you pass, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` flag is set to 1).
 - `defaultName`: (For SaveDialog only) Set this to the file name that should be pre-filled on the dialog.
 - `parentWindow`: Set this to the native window handle of the parent of this dialog.  See the "Usage with a Platform Abstraction Framework" section for details.  It is also possible to pass a handle even if you do not use a platform abstraction framework.
 
@@ -257,7 +257,7 @@ A wildcard filter is always added to every dialog.
 
 *Note 3: On Linux, the file extension is appended (if missing) when the user presses down the "Save" button.  The appended file extension will remain visible to the user, even if an overwrite prompt is shown and the user then presses "Cancel".*
 
-*Note 4: On Windows, the default folder parameter is only used if there is no recently used folder available.  Otherwise, the default folder will be the folder that was last used.  Internally, the Windows implementation calls [IFileDialog::SetDefaultFolder(IShellItem)](https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultfolder).  This is usual Windows behaviour and users expect it.*
+*Note 4: On Windows, the default folder parameter is only used if there is no recently used folder available, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` flag is set to 1.  Otherwise, the default folder will be the folder that was last used.  Internally, the Windows implementation calls [IFileDialog::SetDefaultFolder(IShellItem)](https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultfolder).  This is usual Windows behaviour and users expect it.*
 
 ## Iterating Over PathSets
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ typedef struct {
 ```
 
 - `filterList` and `filterCount`: Set these to customize the file filter (it appears as a dropdown menu on Windows and Linux, but simply hides files on macOS).  Set `filterList` to a pointer to the start of the array of filter items and `filterCount` to the number of filter items in that array.  See the "File Filter Syntax" section below for details.
-- `defaultPath`: Set this to the default folder that the dialog should open to (on Windows, if there is a recently used folder, it opens to that folder instead of the folder you pass, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` flag is set to ON).
+- `defaultPath`: Set this to the default folder that the dialog should open to (on Windows, if there is a recently used folder, it opens to that folder instead of the folder you pass, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` build option is set to ON).
 - `defaultName`: (For SaveDialog only) Set this to the file name that should be pre-filled on the dialog.
 - `parentWindow`: Set this to the native window handle of the parent of this dialog.  See the "Usage with a Platform Abstraction Framework" section for details.  It is also possible to pass a handle even if you do not use a platform abstraction framework.
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ A wildcard filter is always added to every dialog.
 
 *Note 3: On Linux, the file extension is appended (if missing) when the user presses down the "Save" button.  The appended file extension will remain visible to the user, even if an overwrite prompt is shown and the user then presses "Cancel".*
 
-*Note 4: On Windows, the default folder parameter is only used if there is no recently used folder available, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` flag is set to ON.  Otherwise, the default folder will be the folder that was last used.  Internally, the Windows implementation calls [IFileDialog::SetDefaultFolder(IShellItem)](https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultfolder).  This is usual Windows behaviour and users expect it.*
+*Note 4: On Windows, the default folder parameter is only used if there is no recently used folder available, unless the `NFD_OVERRIDE_RECENT_WITH_DEFAULT` build option is set to ON.  Otherwise, the default folder will be the folder that was last used.  Internally, the Windows implementation calls [IFileDialog::SetDefaultFolder(IShellItem)](https://docs.microsoft.com/en-us/windows/desktop/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultfolder).  This is usual Windows behaviour and users expect it.*
 
 ## Iterating Over PathSets
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,3 +138,8 @@ if (NFD_INSTALL)
     FILE ${TARGET_NAME}-config.cmake
   )
 endif()
+
+option(NFD_OVERRIDE_RECENT_WITH_DEFAULT "Use defaultPath instead of recent folder on Windows" ON)
+if (NFD_OVERRIDE_RECENT_WITH_DEFAULT)
+    target_compile_definitions(${TARGET_NAME} PRIVATE nfd_OVERRIDE_RECENT_WITH_DEFAULT)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,5 +141,5 @@ endif()
 
 option(NFD_OVERRIDE_RECENT_WITH_DEFAULT "Use defaultPath instead of recent folder on Windows" ON)
 if (NFD_OVERRIDE_RECENT_WITH_DEFAULT)
-    target_compile_definitions(${TARGET_NAME} PRIVATE nfd_OVERRIDE_RECENT_WITH_DEFAULT)
+    target_compile_definitions(${TARGET_NAME} PRIVATE NFD_OVERRIDE_RECENT_WITH_DEFAULT)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,7 +139,7 @@ if (NFD_INSTALL)
   )
 endif()
 
-option(NFD_OVERRIDE_RECENT_WITH_DEFAULT "Use defaultPath instead of recent folder on Windows" ON)
+option(NFD_OVERRIDE_RECENT_WITH_DEFAULT "Use defaultPath instead of recent folder on Windows" OFF)
 if (NFD_OVERRIDE_RECENT_WITH_DEFAULT)
     target_compile_definitions(${TARGET_NAME} PRIVATE NFD_OVERRIDE_RECENT_WITH_DEFAULT)
 endif()

--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -34,6 +34,9 @@ extern "C" {
 #define NFD_INLINE static inline
 #endif  // __cplusplus
 
+//  If 1, use defaultPath instead of the recent path on Windows.
+extern int NFD_OVERRIDE_RECENT_WITH_DEFAULT;
+
 #include <stddef.h>
 
 typedef char nfdu8char_t;

--- a/src/include/nfd.h
+++ b/src/include/nfd.h
@@ -34,9 +34,6 @@ extern "C" {
 #define NFD_INLINE static inline
 #endif  // __cplusplus
 
-//  If 1, use defaultPath instead of the recent path on Windows.
-extern int NFD_OVERRIDE_RECENT_WITH_DEFAULT;
-
 #include <stddef.h>
 
 typedef char nfdu8char_t;

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -250,7 +250,7 @@ nfdresult_t SetDefaultPath(IFileDialog* dialog, const nfdnchar_t* defaultPath) {
 
     Release_Guard<IShellItem> folderGuard(folder);
 
-#ifdef nfd_OVERRIDE_RECENT_WITH_DEFAULT
+#ifdef NFD_OVERRIDE_RECENT_WITH_DEFAULT
     // Use SetFolder() if you always want to use the default folder
     if (!SUCCEEDED(dialog->SetFolder(folder))) {
         NFDi_SetError("Failed to set default path.");

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -255,7 +255,7 @@ nfdresult_t SetDefaultPath(IFileDialog* dialog, const nfdnchar_t* defaultPath) {
     if (!SUCCEEDED(dialog->SetFolder(folder))) {
         NFDi_SetError("Failed to set default path.");
         return NFD_ERROR;
-    }   
+    }
 #else
     // SetDefaultFolder() might use another recently used folder if available, so the user
     // doesn't need to keep navigating back to the default folder (recommended by Windows).

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -30,6 +30,8 @@ struct IUnknown;  // Workaround for "combaseapi.h(229): error C2187: syntax erro
 #include <windows.h>
 #include "nfd.h"
 
+int NFD_OVERRIDE_RECENT_WITH_DEFAULT = 1;
+
 namespace {
 
 /* current error */
@@ -250,12 +252,19 @@ nfdresult_t SetDefaultPath(IFileDialog* dialog, const nfdnchar_t* defaultPath) {
 
     Release_Guard<IShellItem> folderGuard(folder);
 
-    // SetDefaultFolder() might use another recently used folder if available, so the user doesn't
-    // need to keep navigating back to the default folder (recommended by Windows). change to
-    // SetFolder() if you always want to use the default folder
-    if (!SUCCEEDED(dialog->SetDefaultFolder(folder))) {
-        NFDi_SetError("Failed to set default path.");
-        return NFD_ERROR;
+    if (NFD_OVERRIDE_RECENT_WITH_DEFAULT == 1) {
+        // Use SetFolder() if you always want to use the default folder
+        if (!SUCCEEDED(dialog->SetFolder(folder))) {
+            NFDi_SetError("Failed to set default path.");
+            return NFD_ERROR;
+        }
+    } else {
+        // SetDefaultFolder() might use another recently used folder if available, so the user
+        // doesn't need to keep navigating back to the default folder (recommended by Windows). 
+        if (!SUCCEEDED(dialog->SetDefaultFolder(folder))) {
+            NFDi_SetError("Failed to set default path.");
+            return NFD_ERROR;
+        }
     }
 
     return NFD_OKAY;

--- a/src/nfd_win.cpp
+++ b/src/nfd_win.cpp
@@ -30,8 +30,6 @@ struct IUnknown;  // Workaround for "combaseapi.h(229): error C2187: syntax erro
 #include <windows.h>
 #include "nfd.h"
 
-int NFD_OVERRIDE_RECENT_WITH_DEFAULT = 1;
-
 namespace {
 
 /* current error */
@@ -252,20 +250,20 @@ nfdresult_t SetDefaultPath(IFileDialog* dialog, const nfdnchar_t* defaultPath) {
 
     Release_Guard<IShellItem> folderGuard(folder);
 
-    if (NFD_OVERRIDE_RECENT_WITH_DEFAULT == 1) {
-        // Use SetFolder() if you always want to use the default folder
-        if (!SUCCEEDED(dialog->SetFolder(folder))) {
-            NFDi_SetError("Failed to set default path.");
-            return NFD_ERROR;
-        }
-    } else {
-        // SetDefaultFolder() might use another recently used folder if available, so the user
-        // doesn't need to keep navigating back to the default folder (recommended by Windows). 
-        if (!SUCCEEDED(dialog->SetDefaultFolder(folder))) {
-            NFDi_SetError("Failed to set default path.");
-            return NFD_ERROR;
-        }
+#ifdef nfd_OVERRIDE_RECENT_WITH_DEFAULT
+    // Use SetFolder() if you always want to use the default folder
+    if (!SUCCEEDED(dialog->SetFolder(folder))) {
+        NFDi_SetError("Failed to set default path.");
+        return NFD_ERROR;
+    }   
+#else
+    // SetDefaultFolder() might use another recently used folder if available, so the user
+    // doesn't need to keep navigating back to the default folder (recommended by Windows).
+    if (!SUCCEEDED(dialog->SetDefaultFolder(folder))) {
+        NFDi_SetError("Failed to set default path.");
+        return NFD_ERROR;
     }
+#endif
 
     return NFD_OKAY;
 }


### PR DESCRIPTION
Implements #151 

Implemented using a cmake option with default value set to off.

`src/CMakeLists.txt`
```cmake
option(NFD_OVERRIDE_RECENT_WITH_DEFAULT "Use defaultPath instead of recent folder on Windows" OFF)
if (NFD_OVERRIDE_RECENT_WITH_DEFAULT)
    target_compile_definitions(${TARGET_NAME} PRIVATE NFD_OVERRIDE_RECENT_WITH_DEFAULT)
endif()
```
`nfd_win.cpp`
```c++
#ifdef NFD_OVERRIDE_RECENT_WITH_DEFAULT
    // Use SetFolder() if you always want to use the default folder
    if (!SUCCEEDED(dialog->SetFolder(folder))) {
        NFDi_SetError("Failed to set default path.");
        return NFD_ERROR;
    }
#else
    // SetDefaultFolder() might use another recently used folder if available, so the user
    // doesn't need to keep navigating back to the default folder (recommended by Windows).
    if (!SUCCEEDED(dialog->SetDefaultFolder(folder))) {
        NFDi_SetError("Failed to set default path.");
        return NFD_ERROR;
    }
#endif
```
And then when a downstream app wants to use this they can set the cmake build option to ON:

This makes it so that downstream apps don't need to make any changes to keep the existing behavior, and can just set the build option when they want to use the new behavior.

Screenshots showing the new functionality:

![Screenshot 2024-09-20 000205](https://github.com/user-attachments/assets/3370214d-8de1-43b6-8185-ff97d6d74db6)
![Screenshot 2024-09-20 000215](https://github.com/user-attachments/assets/22e32217-af06-4fa0-8cec-4832113f25b9)
