### PR TITLE
Build: Update minimum CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(nativefiledialog-extended VERSION 1.2.1)
 
 set(nfd_ROOT_PROJECT OFF)
@@ -36,9 +36,7 @@ message("nfd Compiler: ${nfd_COMPILER}")
 
 # Use latest C++ by default (should be the best one), but let user override it
 if(NOT DEFINED CMAKE_CXX_STANDARD)
-  if(CMAKE_VERSION VERSION_LESS "3.8")
-    set (CMAKE_CXX_STANDARD 14)
-  elseif(CMAKE_VERSION VERSION_LESS "3.12")
+  if(CMAKE_VERSION VERSION_LESS "3.12")
     set (CMAKE_CXX_STANDARD 17)
   elseif(CMAKE_VERSION VERSION_LESS "3.20")
     set (CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Same as https://github.com/btzy/nativefiledialog-extended/pull/113, support for CMake versions lower than 3.10 have been deprecated with CMake 3.31

> Compatibility with versions of CMake older than 3.10 is now deprecated and will be removed from a future version. Calls to [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) that set the policy version to an older value now issue a deprecation diagnostic.

Source: https://cmake.org/cmake/help/latest/release/3.31.html#deprecated-and-removed-features