### PR TITLE
CI: Fix Windows Clang (clang-cl) build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -143,6 +143,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Downgrade CMake # force downgrade CMake as later versions try to use the C++ standard flag to compile C programs, which cause an error.
+      run: choco install cmake --version 3.30.6 --allow-downgrade
     - name: Configure
       run: mkdir build && mkdir install && cd build && cmake -DCMAKE_INSTALL_PREFIX="../install" -T ClangCL -DNFD_BUILD_TESTS=ON ..
     - name: Build


### PR DESCRIPTION
CMake 3.31 passes the `-std` flag to clang-cl, even when compiling C code.  This causes clang-cl to abort.  This PR downgrades Clang in the CI build that uses clang-cl.