### PR TITLE
ClangFormat: Use latest version

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,8 +16,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
     - name: Format code
-      # ClangFormat 14 has a bug, which seems to be fixed in ClangFormat 15.  Until GitHub-hosted runners support ClangFormat 15, we will stay at ClangFormat 13.
-      run: find src/ test/ -iname '*.c' -or -iname '*.cpp' -or -iname '*.m' -or -iname '*.mm' -or -iname '*.h' -or -iname '*.hpp' | xargs clang-format-13 -i -style=file
+      run: find src/ test/ -iname '*.c' -or -iname '*.cpp' -or -iname '*.m' -or -iname '*.mm' -or -iname '*.h' -or -iname '*.hpp' | xargs clang-format -i -style=file
     - name: Check diff
       run: git diff --exit-code
 

--- a/src/nfd_portal.cpp
+++ b/src/nfd_portal.cpp
@@ -495,8 +495,7 @@ void AppendSaveFileQueryDictEntryFilters(DBusMessageIter& sub_iter,
         if (defaultName) {
             const nfdnchar_t* p = defaultName;
             while (*p) ++p;
-            while (*--p != '.')
-                ;
+            while (*--p != '.');
             ++p;
             if (*p) extn = p;
         }
@@ -1106,8 +1105,7 @@ bool TryGetValidExtension(const char* extn,
     ++extn;
     if (*extn != '.') return false;
     trimmed_extn = extn;
-    for (++extn; *extn != '\0'; ++extn)
-        ;
+    for (++extn; *extn != '\0'; ++extn);
     ++extn;
     trimmed_extn_end = extn;
     return true;

--- a/test/test_sdl.c
+++ b/test/test_sdl.c
@@ -45,6 +45,10 @@ void show_paths(const nfdpathset_t* paths, SDL_Window* window) {
         NFD_PathSet_FreePathU8(path);
     }
 
+    // We should never return NFD_OKAY with zero paths, but GCC doesn't know this and will emit a
+    // warning that we're trying to malloc with size zero if we write the following line.
+    if (!num_paths) num_chars = 1;
+
     char* message = malloc(num_chars);
     message[0] = '\0';
 


### PR DESCRIPTION
ClangFormat 13 is no longer available on GitHub Actions, so we switch to the newest one, which seems to be ClangFormat 16.

We also fix an over-eager GCC warning in `test_sdl.c`.