### PR TITLE
Linux (GTK, Portal): Fix unintended wchar_t literals

### DIFF
--- a/src/nfd_gtk.cpp
+++ b/src/nfd_gtk.cpp
@@ -92,7 +92,7 @@ void AddFiltersToDialog(GtkFileChooser* chooser,
             // count number of file extensions
             size_t sep = 1;
             for (const nfdnchar_t* p_spec = filterList[index].spec; *p_spec; ++p_spec) {
-                if (*p_spec == L',') {
+                if (*p_spec == ',') {
                     ++sep;
                 }
             }
@@ -192,7 +192,7 @@ Pair_GtkFileFilter_FileExtension* AddFiltersToDialogWithMap(GtkFileChooser* choo
             // count number of file extensions
             size_t sep = 1;
             for (const nfdnchar_t* p_spec = filterList[index].spec; *p_spec; ++p_spec) {
-                if (*p_spec == L',') {
+                if (*p_spec == ',') {
                     ++sep;
                 }
             }

--- a/src/nfd_portal.cpp
+++ b/src/nfd_portal.cpp
@@ -278,7 +278,7 @@ void AppendSingleFilter(DBusMessageIter& base_iter, const nfdnfilteritem_t& filt
     // count number of file extensions
     size_t sep = 1;
     for (const char* p = filter.spec; *p; ++p) {
-        if (*p == L',') {
+        if (*p == ',') {
             ++sep;
         }
     }
@@ -346,7 +346,7 @@ bool AppendSingleFilterCheckExtn(DBusMessageIter& base_iter,
     // count number of file extensions
     size_t sep = 1;
     for (const char* p = filter.spec; *p; ++p) {
-        if (*p == L',') {
+        if (*p == ',') {
             ++sep;
         }
     }


### PR DESCRIPTION
The existing code is technically correct, but using `wchar_t` literals are unintended since we always use UTF-8 on Linux (both GTK and Portal).