### PR TITLE
CI: Switch Ubuntu 20.04 to Ubuntu 22.04

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,7 +42,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ {label: ubuntu-latest, name: latest}, {label: ubuntu-20.04, name: 20.04} ]
+        os: [ {label: ubuntu-latest, name: latest}, {label: ubuntu-22.04, name: 22.04} ]
         portal: [ {flag: OFF, dep: libgtk-3-dev, name: GTK}, {flag: ON, dep: libdbus-1-dev, name: Portal} ] # The NFD_PORTAL setting defaults to OFF (i.e. uses GTK)
         autoappend: [ {flag: OFF, name: NoAppendExtn} ] # By default the NFD_PORTAL mode does not append extensions, because it breaks some features of the portal
         compiler: [ {c: gcc, cpp: g++, name: GCC}, {c: clang, cpp: clang++, name: Clang} ] # The default compiler is gcc/g++


### PR DESCRIPTION
Ubuntu 20.04 is being retired from GitHub Actions.