### PR TITLE
Test: Fix Windows widestring tests built with non-MSVC

### DIFF
--- a/test/test_opendialog_native.c
+++ b/test/test_opendialog_native.c
@@ -29,7 +29,7 @@ int main(void) {
 #ifdef _MSC_VER
         _putws(outPath);
 #else
-        fputws(outPath, stdin);
+        fputws(outPath, stdout);
 #endif
 #else
         puts(outPath);

--- a/test/test_opendialog_native_with.c
+++ b/test/test_opendialog_native_with.c
@@ -32,7 +32,7 @@ int main(void) {
 #ifdef _MSC_VER
         _putws(outPath);
 #else
-        fputws(outPath, stdin);
+        fputws(outPath, stdout);
 #endif
 #else
         puts(outPath);

--- a/test/test_pickfolder_native.c
+++ b/test/test_pickfolder_native.c
@@ -22,7 +22,7 @@ int main(void) {
 #ifdef _MSC_VER
         _putws(outPath);
 #else
-        fputws(outPath, stdin);
+        fputws(outPath, stdout);
 #endif
 #else
         puts(outPath);

--- a/test/test_pickfolder_native_with.c
+++ b/test/test_pickfolder_native_with.c
@@ -23,7 +23,7 @@ int main(void) {
 #ifdef _MSC_VER
         _putws(outPath);
 #else
-        fputws(outPath, stdin);
+        fputws(outPath, stdout);
 #endif
 #else
         puts(outPath);

--- a/test/test_savedialog_native.c
+++ b/test/test_savedialog_native.c
@@ -35,7 +35,7 @@ int main(void) {
 #ifdef _MSC_VER
         _putws(savePath);
 #else
-        fputws(savePath, stdin);
+        fputws(savePath, stdout);
 #endif
 #else
         puts(savePath);

--- a/test/test_savedialog_native_with.c
+++ b/test/test_savedialog_native_with.c
@@ -39,7 +39,7 @@ int main(void) {
 #ifdef _MSC_VER
         _putws(savePath);
 #else
-        fputws(savePath, stdin);
+        fputws(savePath, stdout);
 #endif
 #else
         puts(savePath);


### PR DESCRIPTION
Windows widestring tests don't print the file name when compiled with non-MSVC due to a bug.  This PR fixes it.