### PR TITLE
Linux: Hoist identical code from GTK and Portal implementations into Linux shared header

### DIFF
--- a/src/nfd_gtk.cpp
+++ b/src/nfd_gtk.cpp
@@ -54,71 +54,12 @@ filters to be case-insensitive.
 
 namespace {
 
-template <typename T>
-struct Free_Guard {
-    T* data;
-    Free_Guard(T* freeable) noexcept : data(freeable) {}
-    ~Free_Guard() { NFDi_Free(data); }
-};
-
-template <typename T>
-struct FreeCheck_Guard {
-    T* data;
-    FreeCheck_Guard(T* freeable = nullptr) noexcept : data(freeable) {}
-    ~FreeCheck_Guard() {
-        if (data) NFDi_Free(data);
-    }
-};
-
 /* current error */
 const char* g_errorstr = nullptr;
 
 void NFDi_SetError(const char* msg) {
     g_errorstr = msg;
 }
-
-template <typename T = void>
-T* NFDi_Malloc(size_t bytes) {
-    void* ptr = malloc(bytes);
-    if (!ptr) NFDi_SetError("NFDi_Malloc failed.");
-
-    return static_cast<T*>(ptr);
-}
-
-template <typename T>
-void NFDi_Free(T* ptr) {
-    assert(ptr);
-    free(static_cast<void*>(ptr));
-}
-
-template <typename T>
-T* copy(const T* begin, const T* end, T* out) {
-    for (; begin != end; ++begin) {
-        *out++ = *begin;
-    }
-    return out;
-}
-
-#ifndef NFD_CASE_SENSITIVE_FILTER
-nfdnchar_t* emit_case_insensitive_glob(const nfdnchar_t* begin,
-                                       const nfdnchar_t* end,
-                                       nfdnchar_t* out) {
-    // this code will only make regular Latin characters case-insensitive; other
-    // characters remain case sensitive
-    for (; begin != end; ++begin) {
-        if ((*begin >= 'A' && *begin <= 'Z') || (*begin >= 'a' && *begin <= 'z')) {
-            *out++ = '[';
-            *out++ = *begin;
-            // invert the case of the original character
-            *out++ = *begin ^ static_cast<nfdnchar_t>(0x20);
-            *out++ = ']';
-        } else {
-            *out++ = *begin;
-        }
-    }
-    return out;
-}
-#endif
 
 // Does not own the filter and extension.
 struct Pair_GtkFileFilter_FileExtension {

--- a/src/nfd_linux_shared.hpp
+++ b/src/nfd_linux_shared.hpp
@@ -7,12 +7,76 @@
   These are shared functions for Linux (GTK and Portal).
 */
 
+#include <assert.h>
+#include <stdlib.h>
+
+#include "nfd.h"
+
 #ifdef NFD_WAYLAND
 #include <wayland-client.h>
 #include "xdg-foreign-unstable-v1.h"
 #endif
 
 namespace {
+
+template <typename T = void>
+T* NFDi_Malloc(size_t bytes) {
+    void* ptr = malloc(bytes);
+    assert(ptr);  // Linux malloc never fails
+
+    return static_cast<T*>(ptr);
+}
+
+template <typename T>
+void NFDi_Free(T* ptr) {
+    assert(ptr);
+    free(static_cast<void*>(ptr));
+}
+
+template <typename T>
+struct Free_Guard {
+    T* data;
+    Free_Guard(T* freeable) noexcept : data(freeable) {}
+    ~Free_Guard() { NFDi_Free(data); }
+};
+
+template <typename T>
+struct FreeCheck_Guard {
+    T* data;
+    FreeCheck_Guard(T* freeable = nullptr) noexcept : data(freeable) {}
+    ~FreeCheck_Guard() {
+        if (data) NFDi_Free(data);
+    }
+};
+
+template <typename T>
+T* copy(const T* begin, const T* end, T* out) {
+    for (; begin != end; ++begin) {
+        *out++ = *begin;
+    }
+    return out;
+}
+
+#ifndef NFD_CASE_SENSITIVE_FILTER
+nfdnchar_t* emit_case_insensitive_glob(const nfdnchar_t* begin,
+                                       const nfdnchar_t* end,
+                                       nfdnchar_t* out) {
+    // this code will only make regular Latin characters case-insensitive; other
+    // characters remain case sensitive
+    for (; begin != end; ++begin) {
+        if ((*begin >= 'A' && *begin <= 'Z') || (*begin >= 'a' && *begin <= 'z')) {
+            *out++ = '[';
+            *out++ = *begin;
+            // invert the case of the original character
+            *out++ = *begin ^ static_cast<nfdnchar_t>(0x20);
+            *out++ = ']';
+        } else {
+            *out++ = *begin;
+        }
+    }
+    return out;
+}
+#endif
 
 #ifdef NFD_WAYLAND
 struct wl_display* wayland_display;

--- a/src/nfd_portal.cpp
+++ b/src/nfd_portal.cpp
@@ -47,36 +47,6 @@ filters to be case-insensitive.
 
 namespace {
 
-template <typename T = void>
-T* NFDi_Malloc(size_t bytes) {
-    void* ptr = malloc(bytes);
-    assert(ptr);  // Linux malloc never fails
-
-    return static_cast<T*>(ptr);
-}
-
-template <typename T>
-void NFDi_Free(T* ptr) {
-    assert(ptr);
-    free(static_cast<void*>(ptr));
-}
-
-template <typename T>
-struct Free_Guard {
-    T* data;
-    Free_Guard(T* freeable) noexcept : data(freeable) {}
-    ~Free_Guard() { NFDi_Free(data); }
-};
-
-template <typename T>
-struct FreeCheck_Guard {
-    T* data;
-    FreeCheck_Guard(T* freeable = nullptr) noexcept : data(freeable) {}
-    ~FreeCheck_Guard() {
-        if (data) NFDi_Free(data);
-    }
-};
-
 struct DBusMessage_Guard {
     DBusMessage* data;
     DBusMessage_Guard(DBusMessage* freeable) noexcept : data(freeable) {}
@@ -109,14 +79,6 @@ void NFDi_SetFormattedError(const char* format, ...) {
     err_ptr = owned_err;
 }
 
-template <typename T>
-T* copy(const T* begin, const T* end, T* out) {
-    for (; begin != end; ++begin) {
-        *out++ = *begin;
-    }
-    return out;
-}
-
 template <typename T, typename Callback>
 T* transform(const T* begin, const T* end, T* out, Callback callback) {
     for (; begin != end; ++begin) {
@@ -132,27 +94,6 @@ T* reverse_copy(const T* begin, const T* end, T* out) {
     }
     return out;
 }
-
-#ifndef NFD_CASE_SENSITIVE_FILTER
-nfdnchar_t* emit_case_insensitive_glob(const nfdnchar_t* begin,
-                                       const nfdnchar_t* end,
-                                       nfdnchar_t* out) {
-    // this code will only make regular Latin characters case-insensitive; other
-    // characters remain case sensitive
-    for (; begin != end; ++begin) {
-        if ((*begin >= 'A' && *begin <= 'Z') || (*begin >= 'a' && *begin <= 'z')) {
-            *out++ = '[';
-            *out++ = *begin;
-            // invert the case of the original character
-            *out++ = *begin ^ static_cast<nfdnchar_t>(0x20);
-            *out++ = ']';
-        } else {
-            *out++ = *begin;
-        }
-    }
-    return out;
-}
-#endif
 
 // Returns true if ch is in [0-9A-Za-z], false otherwise.
 bool IsHex(char ch) {


### PR DESCRIPTION
The original NFDi_Malloc for GTK sets an error message if it fails, but this never happens since Linux overcommits memory, so now we simply assert that malloc() returns a non-null pointer.