### PR TITLE
ClangFormat: Bump to version 20

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,10 +15,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install clang-format-20
     - name: Check version
-      run: clang-format --version
+      run: clang-format-20 --version
     - name: Format code
-      run: find src/ test/ -iname '*.c' -or -iname '*.cpp' -or -iname '*.m' -or -iname '*.mm' -or -iname '*.h' -or -iname '*.hpp' | xargs clang-format -i -style=file
+      run: find src/ test/ -iname '*.c' -or -iname '*.cpp' -or -iname '*.m' -or -iname '*.mm' -or -iname '*.h' -or -iname '*.hpp' | xargs clang-format-20 -i -style=file
     - name: Check diff
       run: git diff --exit-code
 

--- a/src/nfd_gtk.cpp
+++ b/src/nfd_gtk.cpp
@@ -415,9 +415,8 @@ void zxdg_exported_v1_handle(void* context, struct zxdg_exported_v1*, const char
     gdk_wayland_window_set_transient_for_exported(childWindow, const_cast<char*>(handle));
 }
 
-constexpr struct zxdg_exported_v1_listener wayland_xdg_exported_v1_listener {
-    &zxdg_exported_v1_handle
-};
+constexpr struct zxdg_exported_v1_listener wayland_xdg_exported_v1_listener{
+    &zxdg_exported_v1_handle};
 #endif
 
 // This is an RAII class that wraps the parenting of a GtkWidget (the file dialog).

--- a/src/nfd_portal.cpp
+++ b/src/nfd_portal.cpp
@@ -162,9 +162,8 @@ void zxdg_exported_v1_handle(void* context, struct zxdg_exported_v1*, const char
     NFDi_Free(buf);
 }
 
-constexpr struct zxdg_exported_v1_listener wayland_xdg_exported_v1_listener {
-    &zxdg_exported_v1_handle
-};
+constexpr struct zxdg_exported_v1_listener wayland_xdg_exported_v1_listener{
+    &zxdg_exported_v1_handle};
 #endif
 
 void AppendOpenFileQueryParentWindow(DBusMessageIter& iter,


### PR DESCRIPTION
The default version on ubuntu-latest (24.04) is currently 18, but that's kind of old and it formats things a bit differently.